### PR TITLE
Improving "quiet" login in Sanic exceptions

### DIFF
--- a/sanic/exceptions.py
+++ b/sanic/exceptions.py
@@ -11,9 +11,16 @@ def add_status_code(code, quiet=None):
 
     def class_decorator(cls):
         cls.status_code = code
-        if quiet or quiet is None and code != 500:
+
+        if quiet is not None:
+            cls.quiet = quiet
+        elif code == 500:
+            cls.quiet = False
+        else:
             cls.quiet = True
+
         _sanic_exceptions[code] = cls
+
         return cls
 
     return class_decorator
@@ -27,8 +34,14 @@ class SanicException(Exception):
             self.status_code = status_code
 
         # quiet=None/False/True with None meaning choose by status
-        if quiet or quiet is None and status_code not in (None, 500):
+        if quiet is not None:
+            self.quiet = quiet
+        elif hasattr(type(self), "quiet"):
+            pass
+        elif status_code not in (None, 500):
             self.quiet = True
+        else
+            self.quiet = False
 
 
 @add_status_code(404)

--- a/sanic/exceptions.py
+++ b/sanic/exceptions.py
@@ -14,10 +14,8 @@ def add_status_code(code, quiet=None):
 
         if quiet is not None:
             cls.quiet = quiet
-        elif code == 500:
-            cls.quiet = False
-        else:
-            cls.quiet = True
+        else
+            cls.quiet = code != 500
 
         _sanic_exceptions[code] = cls
 
@@ -38,10 +36,8 @@ class SanicException(Exception):
             self.quiet = quiet
         elif hasattr(type(self), "quiet"):
             pass
-        elif status_code in (None, 500):
-            self.quiet = False
         else
-            self.quiet = True
+            self.quiet = status_code not in (None, 500)
 
 
 @add_status_code(404)

--- a/sanic/exceptions.py
+++ b/sanic/exceptions.py
@@ -38,10 +38,10 @@ class SanicException(Exception):
             self.quiet = quiet
         elif hasattr(type(self), "quiet"):
             pass
-        elif status_code not in (None, 500):
-            self.quiet = True
-        else
+        elif status_code in (None, 500):
             self.quiet = False
+        else
+            self.quiet = True
 
 
 @add_status_code(404)


### PR DESCRIPTION
Logic for setting quiet attribute for exception instance may be wrong,
or I do not understand intention behind it (if so please explain it to me).

What I mean by wrong:


!500 and !None

| quiet provided to decorator | quiet provided to init | quiet in exception instance ||
|-|-|-|-|
| True | False | True | But because I explicitly provided False when instantiating exception I expect quiet in this instance to be False |
| False | None | True | But because I explicitly provided False to decorator I expect quiet in this instance  to be False |

I can plot table with more examples like that.

So I propose a more straightforward logic for setting quiet attribute.
Please take a look, comment or If I am wrong explain.