### PR TITLE
Raise ValueError when cookie max-age is not an integer

### DIFF
--- a/examples/run_asgi.py
+++ b/examples/run_asgi.py
@@ -19,21 +19,34 @@ def handler_text(request):
     return response.text("Hello")
 
 
+@app.route("/cookie")
+def handler_cookie(request):
+    resp = response.text("Hello")
+
+    resp.cookies["my-cookie"] = "foo"
+    resp.cookies["my-cookie"]["max-age"] = 10.0  # max-age is set to 10
+    # resp.cookies["my-cookie"]["max-age"] = 10.5  # raise ValueError
+    # resp.cookies["my-cookie"]["max-age"] = "ten"  # raise ValueError
+    # resp.cookies["my-cookie"]["max-age"] = "10"  # max-age is set to 10
+    # resp.cookies["my-cookie"]["max-age"] = 10  # max-age is set to 10
+    return resp
+
+
 @app.route("/json")
 def handler_json(request):
     return response.json({"foo": "bar"})
 
 
-@app.websocket("/ws")
-async def handler_ws(request, ws):
-    name = "<someone>"
-    while True:
-        data = f"Hello {name}"
-        await ws.send(data)
-        name = await ws.recv()
+# @app.websocket("/ws")
+# async def handler_ws(request, ws):
+#     name = "<someone>"
+#     while True:
+#         data = f"Hello {name}"
+#         await ws.send(data)
+#         name = await ws.recv()
 
-        if not name:
-            break
+#         if not name:
+#             break
 
 
 @app.route("/file")

--- a/examples/run_asgi.py
+++ b/examples/run_asgi.py
@@ -19,34 +19,21 @@ def handler_text(request):
     return response.text("Hello")
 
 
-@app.route("/cookie")
-def handler_cookie(request):
-    resp = response.text("Hello")
-
-    resp.cookies["my-cookie"] = "foo"
-    resp.cookies["my-cookie"]["max-age"] = 10.0  # max-age is set to 10
-    # resp.cookies["my-cookie"]["max-age"] = 10.5  # raise ValueError
-    # resp.cookies["my-cookie"]["max-age"] = "ten"  # raise ValueError
-    # resp.cookies["my-cookie"]["max-age"] = "10"  # max-age is set to 10
-    # resp.cookies["my-cookie"]["max-age"] = 10  # max-age is set to 10
-    return resp
-
-
 @app.route("/json")
 def handler_json(request):
     return response.json({"foo": "bar"})
 
 
-# @app.websocket("/ws")
-# async def handler_ws(request, ws):
-#     name = "<someone>"
-#     while True:
-#         data = f"Hello {name}"
-#         await ws.send(data)
-#         name = await ws.recv()
+@app.websocket("/ws")
+async def handler_ws(request, ws):
+    name = "<someone>"
+    while True:
+        data = f"Hello {name}"
+        await ws.send(data)
+        name = await ws.recv()
 
-#         if not name:
-#             break
+        if not name:
+            break
 
 
 @app.route("/file")

--- a/sanic/cookies.py
+++ b/sanic/cookies.py
@@ -2,7 +2,6 @@ import re
 import string
 
 from datetime import datetime
-from multiprocessing import Value
 
 
 DEFAULT_MAX_AGE = 0

--- a/sanic/cookies.py
+++ b/sanic/cookies.py
@@ -2,6 +2,7 @@ import re
 import string
 
 from datetime import datetime
+from multiprocessing import Value
 
 
 DEFAULT_MAX_AGE = 0
@@ -109,7 +110,7 @@ class Cookie(dict):
         if value is not False:
             if key.lower() == "max-age":
                 if not str(value).isdigit():
-                    value = DEFAULT_MAX_AGE
+                    raise ValueError("Cookie max-age must be an integer")
             elif key.lower() == "expires":
                 if not isinstance(value, datetime):
                     raise TypeError(

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -162,7 +162,7 @@ def test_cookie_set_same_key(app):
     assert response.cookies["test"] == "pass"
 
 
-@pytest.mark.parametrize("max_age", ["0", 30, 30.0, 30.1, "30", "test"])
+@pytest.mark.parametrize("max_age", ["0", 30, "30"])
 def test_cookie_max_age(app, max_age):
     cookies = {"test": "wait"}
 
@@ -202,6 +202,23 @@ def test_cookie_max_age(app, max_age):
         )
     else:
         assert cookie is None
+
+
+@pytest.mark.parametrize("max_age", [30.0, 30.1, "test"])
+def test_cookie_bad_max_age(app, max_age):
+    cookies = {"test": "wait"}
+
+    @app.get("/")
+    def handler(request):
+        response = text("pass")
+        response.cookies["test"] = "pass"
+        response.cookies["test"]["max-age"] = max_age
+        return response
+
+    request, response = app.test_client.get(
+        "/", cookies=cookies, raw_cookies=True
+    )
+    assert response.status == 500
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This fixes #1810. It is slightly different than the proposed solution which stated that a whole number float should be valid.

This change will now raise a ValueError whenever a non-integer is passed as a max-age. It still accepts `"10"`.