### PR TITLE
Replace ujson with orjson

### DIFF
--- a/sanic/response.py
+++ b/sanic/response.py
@@ -10,7 +10,7 @@ from sanic.helpers import has_message_body, remove_entity_headers
 
 
 try:
-    from ujson import dumps as json_dumps
+    from orjson import dumps as json_dumps
 except ImportError:
     # This is done in order to ensure that the JSON response is
     # kept consistent across both ujson and inbuilt json usage.

--- a/setup.py
+++ b/setup.py
@@ -79,13 +79,12 @@ setup_kwargs = {
 env_dependency = (
     '; sys_platform != "win32" ' 'and implementation_name == "cpython"'
 )
-ujson = "ujson>=1.35" + env_dependency
 uvloop = "uvloop>=0.5.3" + env_dependency
 
 requirements = [
     "httptools>=0.0.10",
     uvloop,
-    ujson,
+    "orjson>=3.4.6",
     "aiofiles>=0.6.0",
     "websockets>=8.1,<9.0",
     "multidict>=5.0,<6.0",
@@ -100,7 +99,7 @@ tests_require = [
     "httpcore==0.11.*",
     "beautifulsoup4",
     uvloop,
-    ujson,
+    "orjson>=3.4.6",
     "pytest-sanic",
     "pytest-sugar",
     "pytest-benchmark",

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -166,7 +166,7 @@ def test_json_response(json_app):
 
     request, response = json_app.test_client.get("/")
     assert response.status == 200
-    assert response.text == json_dumps(JSON_DATA)
+    assert response.text == json_dumps(JSON_DATA).decode()
     assert response.json == JSON_DATA
 
 


### PR DESCRIPTION
There are lots of benchmarks showing `orjson` to be faster than `usjon`. And, now is the time to make breaking changes if we will this year. This is a fairly trivial test just to see what it would look like. On large responses, I actually saw a HUGE degradation in performance. So, perhaps we need to look closer to see if this is even worthwhile in Sanic.

See #1479