### PR TITLE
Remove prefix from websocket handler name

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -524,9 +524,7 @@ class Sanic:
             websocket_handler = partial(
                 self._websocket_handler, handler, subprotocols=subprotocols
             )
-            websocket_handler.__name__ = (
-                "websocket_handler_" + handler.__name__
-            )
+            websocket_handler.__name__ = handler.__name__
             websocket_handler.is_websocket = True
             routes.extend(
                 self.router.add(


### PR DESCRIPTION
Update: opened for wrong branch, reopened another pr.

---

Remove the websocket prefix `websocket_handler_` introduced in
761eef7. It makes `url_for()` unable to find the corresponding ws route.

```python
@app.websocket('/ws')
async def websocket(request, ws):
    return ""
```

The key for the above handler used in `Router.route_names` is `websocket_handler_websocket`, not `websocket`. Removing the `websocket_handler_` prefix fixes this bug. Searching in the source code, this very prefix is not used in anywhere.

I guess the contributor of commit 761eef7 tried to mimic the registration behavior of static file handler, which prepend the handler name with prefix `_static_`, in order to store static file handler separately in `Router.routes_static_files`, not in `Router.routes_names`.