### PR TITLE
[20.12LTS] Remove prefix from websocket handler name

### DIFF
--- a/tests/test_url_building.py
+++ b/tests/test_url_building.py
@@ -348,3 +348,13 @@ def test_methodview_naming(methodview_app):
 
     assert viewone_url == "/view_one"
     assert viewtwo_url == "/view_two"
+
+
+def test_url_for_with_websocket_handlers(app):
+    # Test for a specific bugfix in GH-2021
+    @app.websocket("/ws")
+    async def my_handler(request, ws):
+        pass
+
+    assert app.url_for("my_handler") == "/ws"
+    assert app.url_for("websocket_handler_my_handler") == "/ws"


### PR DESCRIPTION
Formerly try to open for master branch GH-2020. Cause the Router is overhauled on master, open this pr for 20.12LTS.

---

Remove the websocket prefix `websocket_handler_` introduced in
761eef7. Makes `url_for()` unable to find the corresponding ws route for non-bp websocket view.

```python
@app.websocket('/ws')
async def websocket(request, ws):
    return ""
```

The key for the above handler used in `Router.route_names` is `websocket_handler_websocket`, not `websocket`. Removing the `websocket_handler_` prefix fixes this bug. Searching in the source code, this very prefix is not used in anywhere.

I guess the contributor of commit 761eef7 tried to mimic the registration behavior of static file handler, which prepend the handler name with prefix `_static_`, in order to store static file handler separately in `Router.routes_static_files`, not in `Router.routes_names`.