### PR TITLE
Fix uvloop to 0.14.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ env_dependency = (
     '; sys_platform != "win32" ' 'and implementation_name == "cpython"'
 )
 ujson = "ujson>=1.35" + env_dependency
-uvloop = "uvloop==0.14.0" + env_dependency
+uvloop = "uvloop>=0.5.3,<0.15.0" + env_dependency
 
 requirements = [
     "httptools>=0.0.10",

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,8 @@ setup_kwargs = {
     "author": "Sanic Community",
     "author_email": "admhpkns@gmail.com",
     "description": (
-        "A web server and web framework that's written to go fast. Build fast. Run fast."
+        "A web server and web framework that's written to go fast. "
+        "Build fast. Run fast."
     ),
     "long_description": long_description,
     "packages": ["sanic"],
@@ -80,7 +81,7 @@ env_dependency = (
     '; sys_platform != "win32" ' 'and implementation_name == "cpython"'
 )
 ujson = "ujson>=1.35" + env_dependency
-uvloop = "uvloop>=0.5.3" + env_dependency
+uvloop = "uvloop==0.14.0" + env_dependency
 
 requirements = [
     "httptools>=0.0.10",


### PR DESCRIPTION
uvloop is [dropping python 3.6](https://github.com/MagicStack/uvloop/releases/tag/v0.15.0) support. I think [we should also](https://community.sanicframework.org/t/dropping-python-3-6/793/4), but I am not quite ready to do that in v21.3. In the mean time, let's fix uvloop to 0.14. Also making a PR for LTS.