### PR TITLE
Fix tox requirement install dependency problems in 19.12LTS

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
     pytest-sugar
     httpcore==0.3.0
     httpx==0.9.3
-    chardet<=2.3.0
+    multidict==5.0.0
     beautifulsoup4
     gunicorn
     pytest-benchmark


### PR DESCRIPTION
Remove old chardet requirement, add in our hard multidict requirement