### PR TITLE
Router tweaks

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -394,7 +394,12 @@ class Sanic(BaseSanic):
 
                 kwargs["file_uri"] = filename
 
-        if uri != "/" and uri.endswith("/"):
+        if (
+            uri != "/"
+            and uri.endswith("/")
+            and not route.strict
+            and not route.raw_path[:-1]
+        ):
             uri = uri[:-1]
 
         if not uri.startswith("/"):

--- a/sanic/mixins/routes.py
+++ b/sanic/mixins/routes.py
@@ -611,7 +611,7 @@ class RouteMixin:
                 else:
                     break
 
-        if not name:  # noq
+        if not name:  # noqa
             raise ValueError("Could not generate a name for handler")
 
         if not name.startswith(f"{self.name}."):

--- a/sanic/mixins/routes.py
+++ b/sanic/mixins/routes.py
@@ -627,19 +627,19 @@ class RouteMixin:
         stream_large_files,
         request,
         content_type=None,
-        file_uri=None,
+        __file_uri__=None,
     ):
         # Using this to determine if the URL is trying to break out of the path
         # served.  os.path.realpath seems to be very slow
-        if file_uri and "../" in file_uri:
+        if __file_uri__ and "../" in __file_uri__:
             raise InvalidUsage("Invalid URL")
         # Merge served directory and requested file if provided
         # Strip all / that in the beginning of the URL to help prevent python
         # from herping a derp and treating the uri as an absolute path
         root_path = file_path = file_or_directory
-        if file_uri:
+        if __file_uri__:
             file_path = path.join(
-                file_or_directory, sub("^[/]*", "", file_uri)
+                file_or_directory, sub("^[/]*", "", __file_uri__)
             )
 
         # URL decode the path sent by the browser otherwise we won't be able to
@@ -648,10 +648,12 @@ class RouteMixin:
         if not file_path.startswith(path.abspath(unquote(root_path))):
             error_logger.exception(
                 f"File not found: path={file_or_directory}, "
-                f"relative_url={file_uri}"
+                f"relative_url={__file_uri__}"
             )
             raise FileNotFound(
-                "File not found", path=file_or_directory, relative_url=file_uri
+                "File not found",
+                path=file_or_directory,
+                relative_url=__file_uri__,
             )
         try:
             headers = {}
@@ -719,10 +721,12 @@ class RouteMixin:
         except Exception:
             error_logger.exception(
                 f"File not found: path={file_or_directory}, "
-                f"relative_url={file_uri}"
+                f"relative_url={__file_uri__}"
             )
             raise FileNotFound(
-                "File not found", path=file_or_directory, relative_url=file_uri
+                "File not found",
+                path=file_or_directory,
+                relative_url=__file_uri__,
             )
 
     def _register_static(
@@ -772,7 +776,7 @@ class RouteMixin:
         # If we're not trying to match a file directly,
         # serve from the folder
         if not path.isfile(file_or_directory):
-            uri += "/<file_uri>"
+            uri += "/<__file_uri__>"
 
         # special prefix for static files
         # if not static.name.startswith("_static_"):

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -147,7 +147,7 @@ class Request:
         ] = defaultdict(list)
         self.uri_template: Optional[str] = None
         self.request_middleware_started = False
-        self._cookies: Dict[str, str] = {}
+        self._cookies: Optional[Dict[str, str]] = None
         self._match_info = {}
         self.stream: Optional[Http] = None
         self.endpoint: Optional[str] = None
@@ -183,8 +183,7 @@ class Request:
             response = await self.app._run_response_middleware(
                 self, response, request_name=self.name
             )
-        # Redefining this as a tuple here satisfies mypy
-        except tuple(*CancelledErrors):
+        except CancelledErrors:
             raise
         except Exception:
             error_logger.exception(
@@ -432,6 +431,7 @@ class Request:
         :return: Incoming cookies on the request
         :rtype: Dict[str, str]
         """
+
         if self._cookies is None:
             cookie = self.headers.get("Cookie")
             if cookie is not None:

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -12,6 +12,8 @@ from typing import (
     Union,
 )
 
+from sanic_routing.route import Route
+
 
 if TYPE_CHECKING:
     from sanic.server import ConnInfo
@@ -104,6 +106,7 @@ class Request:
         "parsed_forwarded",
         "raw_url",
         "request_middleware_started",
+        "route",
         "stream",
         "transport",
         "uri_template",
@@ -151,6 +154,7 @@ class Request:
         self._match_info = {}
         self.stream: Optional[Http] = None
         self.endpoint: Optional[str] = None
+        self.route: Optional[Route] = None
 
     def __repr__(self):
         class_name = self.__class__.__name__

--- a/tests/benchmark/test_route_resolution_benchmark.py
+++ b/tests/benchmark/test_route_resolution_benchmark.py
@@ -39,7 +39,7 @@ class TestSanicRouteResolution:
             iterations=1000,
             rounds=1000,
         )
-        assert await result[0](None) == 1
+        assert await result[1](None) == 1
 
     @mark.asyncio
     async def test_resolve_route_with_typed_args(
@@ -72,4 +72,4 @@ class TestSanicRouteResolution:
             iterations=1000,
             rounds=1000,
         )
-        assert await result[0](None) == 1
+        assert await result[1](None) == 1

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,7 +4,7 @@ import sys
 
 from inspect import isawaitable
 from os import environ
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -118,7 +118,7 @@ def test_app_route_raise_value_error(app):
 
 def test_app_handle_request_handler_is_none(app, monkeypatch):
     def mockreturn(*args, **kwargs):
-        return None, {}, "", "", False
+        return Mock(), None, {}
 
     # Not sure how to make app.router.get() return None, so use mock here.
     monkeypatch.setattr(app.router, "get", mockreturn)

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -752,7 +752,7 @@ def test_static_blueprint_name(static_file_directory, file_name):
     app.blueprint(bp)
 
     uri = app.url_for("static", name="static.testing")
-    assert uri == "/static/test.file"
+    assert uri == "/static/test.file/"
 
     _, response = app.test_client.get("/static/test.file")
     assert response.status == 404

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -15,6 +15,8 @@ from sanic.response import text
 def test_cookies(app):
     @app.route("/")
     def handler(request):
+        print(request.headers)
+        print(request.cookies)
         cookie_value = request.cookies["test"]
         response = text(f"Cookies are: {cookie_value}")
         response.cookies["right_back"] = "at you"

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -15,8 +15,6 @@ from sanic.response import text
 def test_cookies(app):
     @app.route("/")
     def handler(request):
-        print(request.headers)
-        print(request.cookies)
         cookie_value = request.cookies["test"]
         response = text(f"Cookies are: {cookie_value}")
         response.cookies["right_back"] = "at you"

--- a/tests/test_exceptions_handler.py
+++ b/tests/test_exceptions_handler.py
@@ -126,7 +126,6 @@ def test_html_traceback_output_in_debug_mode():
     assert response.status == 500
     soup = BeautifulSoup(response.body, "html.parser")
     html = str(soup)
-    print(html)
 
     assert "response = handler(request, **kwargs)" in html
     assert "handler_4" in html

--- a/tests/test_reloader.py
+++ b/tests/test_reloader.py
@@ -59,7 +59,6 @@ def write_app(filename, **runargs):
 def scanner(proc):
     for line in proc.stdout:
         line = line.decode().strip()
-        print(">", line)
         if line.startswith("complete"):
             yield line
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -74,3 +74,12 @@ def test_custom_generator():
         "/", headers={"SOME-OTHER-REQUEST-ID": f"{REQUEST_ID}"}
     )
     assert request.id == REQUEST_ID * 2
+
+
+def test_route_assigned_to_request(app):
+    @app.get("/")
+    async def get(request):
+        return response.empty()
+
+    request, _ = app.test_client.get("/")
+    assert request.route is list(app.router.routes.values())[0]

--- a/tests/test_request_stream.py
+++ b/tests/test_request_stream.py
@@ -59,7 +59,6 @@ def test_request_stream_100_continue(app, headers, expect_raise_exception):
             result = ""
             while True:
                 body = await request.stream.read()
-                print(f"{body=}")
                 if body is None:
                     break
                 result += body.decode("utf-8")
@@ -647,7 +646,6 @@ def test_streaming_echo():
                 data = await reader.read(4096)
                 assert data
                 buffer += data
-                print(res)
             assert buffer[size : size + 2] == b"\r\n"
             ret, buffer = buffer[:size], buffer[size + 2 :]
             return ret

--- a/tests/test_request_stream.py
+++ b/tests/test_request_stream.py
@@ -59,6 +59,7 @@ def test_request_stream_100_continue(app, headers, expect_raise_exception):
             result = ""
             while True:
                 body = await request.stream.read()
+                print(f"{body=}")
                 if body is None:
                     break
                 result += body.decode("utf-8")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -194,7 +194,6 @@ def test_versioned_routes_get(app, method):
             return text("OK")
 
     else:
-        print(func)
         raise Exception(f"Method: {method} is not callable")
 
     client_method = getattr(app.test_client, method)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,15 +1,20 @@
 import asyncio
+import re
 
 from unittest.mock import Mock
 
 import pytest
 
-from sanic_routing.exceptions import ParameterNameConflicts, RouteExists
+from sanic_routing.exceptions import (
+    InvalidUsage,
+    ParameterNameConflicts,
+    RouteExists,
+)
 from sanic_testing.testing import SanicTestClient
 
 from sanic import Blueprint, Sanic
 from sanic.constants import HTTP_METHODS
-from sanic.exceptions import NotFound
+from sanic.exceptions import NotFound, SanicException
 from sanic.request import Request
 from sanic.response import json, text
 
@@ -1113,3 +1118,59 @@ def test_route_invalid_host(app):
     assert str(excinfo.value) == (
         "Expected either string or Iterable of " "host strings, not {!r}"
     ).format(host)
+
+
+def test_route_with_regex_group(app):
+    @app.route("/path/to/<ext:file\.(txt)>")
+    async def handler(request, ext):
+        return text(ext)
+
+    _, response = app.test_client.get("/path/to/file.txt")
+    assert response.text == "txt"
+
+
+def test_route_with_regex_named_group(app):
+    @app.route(r"/path/to/<ext:file\.(?P<ext>txt)>")
+    async def handler(request, ext):
+        return text(ext)
+
+    _, response = app.test_client.get("/path/to/file.txt")
+    assert response.text == "txt"
+
+
+def test_route_with_regex_named_group_invalid(app):
+    @app.route(r"/path/to/<ext:file\.(?P<wrong>txt)>")
+    async def handler(request, ext):
+        return text(ext)
+
+    with pytest.raises(InvalidUsage) as e:
+        app.router.finalize()
+
+    assert e.match(
+        re.escape("Named group (wrong) must match your named parameter (ext)")
+    )
+
+
+def test_route_with_regex_group_ambiguous(app):
+    @app.route("/path/to/<ext:file(?:\.)(txt)>")
+    async def handler(request, ext):
+        return text(ext)
+
+    with pytest.raises(InvalidUsage) as e:
+        app.router.finalize()
+
+    assert e.match(
+        re.escape(
+            "Could not compile pattern file(?:\.)(txt). Try using a named "
+            "group instead: '(?P<ext>your_matching_group)'"
+        )
+    )
+
+
+def test_route_with_bad_named_param(app):
+    @app.route("/foo/<__bar__>")
+    async def handler(request):
+        return text("...")
+
+    with pytest.raises(SanicException):
+        app.router.finalize()

--- a/tests/test_url_building.py
+++ b/tests/test_url_building.py
@@ -344,3 +344,23 @@ def test_methodview_naming(methodview_app):
 
     assert viewone_url == "/view_one"
     assert viewtwo_url == "/view_two"
+
+
+@pytest.mark.parametrize(
+    "path,version,expected",
+    (
+        ("/foo", 1, "/v1/foo"),
+        ("/foo", 1.1, "/v1.1/foo"),
+        ("/foo", "1", "/v1/foo"),
+        ("/foo", "1.1", "/v1.1/foo"),
+        ("/foo", "1.0.1", "/v1.0.1/foo"),
+        ("/foo", "v1.0.1", "/v1.0.1/foo"),
+    ),
+)
+def test_versioning(app, path, version, expected):
+    @app.route(path, version=version)
+    def handler(*_):
+        ...
+
+    url = app.url_for("handler")
+    assert url == expected

--- a/tests/test_url_for.py
+++ b/tests/test_url_for.py
@@ -88,3 +88,19 @@ def test_websocket_bp_route_name(app):
 
 # TODO: add test with a route with multiple hosts
 # TODO: add test with a route with _host in url_for
+@pytest.mark.parametrize(
+    "path,strict,expected",
+    (
+        ("/foo", False, "/foo"),
+        ("/foo/", False, "/foo"),
+        ("/foo", True, "/foo"),
+        ("/foo/", True, "/foo/"),
+    ),
+)
+def test_trailing_slash_url_for(app, path, strict, expected):
+    @app.route(path, strict_slashes=strict)
+    def handler(*_):
+        ...
+
+    url = app.url_for("handler")
+    assert url == expected


### PR DESCRIPTION
- Branches off #2006, so merge that first.
- Fixes #1420 (`url_for` where `strict_slashes` are on for a path ending in `/`)
- Fixes #1525 to allow for partial matching
- Adds `Request.route`
- Allow for partial regex matching