### PR TITLE
Remove Python 3.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,6 @@ cache:
     - $HOME/.cache/pip
 matrix:
   include:
-    - env: TOX_ENV=py36
-      python: 3.6
-      name: "Python 3.6 with Extensions"
-    - env: TOX_ENV=py36-no-ext
-      python: 3.6
-      name: "Python 3.6 without Extensions"
     - env: TOX_ENV=py37
       python: 3.7
       dist: xenial
@@ -42,9 +36,6 @@ matrix:
       sudo: true
       name: "Python 3.9 without Extensions"
     - env: TOX_ENV=type-checking
-      python: 3.6
-      name: "Python 3.6 Type checks"
-    - env: TOX_ENV=type-checking
       python: 3.7
       name: "Python 3.7 Type checks"
     - env: TOX_ENV=type-checking
@@ -54,17 +45,6 @@ matrix:
       python: 3.9
       dist: bionic
       name: "Python 3.9 Type checks"
-    - env: TOX_ENV=lint
-      python: 3.6
-      name: "Python 3.6 Linter checks"
-    - env: TOX_ENV=check
-      python: 3.6
-      name: "Python 3.6 Package checks"
-    - env: TOX_ENV=security
-      python: 3.6
-      dist: xenial
-      sudo: true
-      name: "Python 3.6 Bandit security scan"
     - env: TOX_ENV=security
       python: 3.7
       dist: xenial

--- a/README.rst
+++ b/README.rst
@@ -130,6 +130,7 @@ And, we can verify it is working: ``curl localhost:8000 -i``
 
 **Now, let's go build something fast!**
 
+Minimum Python version is 3.7. If you need Python 3.6 support, please use v20.12LTS.
 
 Documentation
 -------------

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -4,7 +4,6 @@ import os
 import secrets
 import socket
 import stat
-import sys
 
 from asyncio import CancelledError
 from functools import partial
@@ -125,7 +124,6 @@ class HttpProtocol(asyncio.Protocol):
     ):
         asyncio.set_event_loop(loop)
         self.loop = loop
-        deprecated_loop = self.loop if sys.version_info < (3, 7) else None
         self.app = app
         self.url = None
         self.transport = None
@@ -147,8 +145,8 @@ class HttpProtocol(asyncio.Protocol):
         self.state = state if state else {}
         if "requests_count" not in self.state:
             self.state["requests_count"] = 0
-        self._data_received = asyncio.Event(loop=deprecated_loop)
-        self._can_write = asyncio.Event(loop=deprecated_loop)
+        self._data_received = asyncio.Event()
+        self._can_write = asyncio.Event()
         self._can_write.set()
         self._exception = None
         self._unix = unix

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -36,7 +36,9 @@ class Signal:
 
 
 class ConnInfo:
-    """Local and remote addresses and SSL status info."""
+    """
+    Local and remote addresses and SSL status info.
+    """
 
     __slots__ = (
         "sockname",

--- a/setup.py
+++ b/setup.py
@@ -64,12 +64,11 @@ setup_kwargs = {
     "packages": ["sanic"],
     "package_data": {"sanic": ["py.typed"]},
     "platforms": "any",
-    "python_requires": ">=3.6",
+    "python_requires": ">=3.7",
     "classifiers": [
         "Development Status :: 4 - Beta",
         "Environment :: Web Environment",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -81,7 +80,7 @@ env_dependency = (
     '; sys_platform != "win32" ' 'and implementation_name == "cpython"'
 )
 ujson = "ujson>=1.35" + env_dependency
-uvloop = "uvloop>=0.5.3,<0.15.0" + env_dependency
+uvloop = "uvloop>=0.5.3" + env_dependency
 
 requirements = [
     "sanic-routing",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -32,9 +32,6 @@ def test_app_loop_running(app):
     assert response.text == "pass"
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 7), reason="requires python3.7 or higher"
-)
 def test_create_asyncio_server(app):
     if not uvloop_installed():
         loop = asyncio.get_event_loop()
@@ -44,9 +41,6 @@ def test_create_asyncio_server(app):
         assert srv.is_serving() is True
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 7), reason="requires python3.7 or higher"
-)
 def test_asyncio_server_no_start_serving(app):
     if not uvloop_installed():
         loop = asyncio.get_event_loop()
@@ -59,9 +53,6 @@ def test_asyncio_server_no_start_serving(app):
         assert srv.is_serving() is False
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 7), reason="requires python3.7 or higher"
-)
 def test_asyncio_server_start_serving(app):
     if not uvloop_installed():
         loop = asyncio.get_event_loop()

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -86,11 +86,7 @@ def test_listeners_triggered():
     with pytest.warns(UserWarning):
         server.run()
 
-    all_tasks = (
-        asyncio.Task.all_tasks()
-        if sys.version_info < (3, 7)
-        else asyncio.all_tasks(asyncio.get_event_loop())
-    )
+    all_tasks = asyncio.all_tasks(asyncio.get_event_loop())
     for task in all_tasks:
         task.cancel()
 
@@ -140,11 +136,7 @@ def test_listeners_triggered_async(app):
     with pytest.warns(UserWarning):
         server.run()
 
-    all_tasks = (
-        asyncio.Task.all_tasks()
-        if sys.version_info < (3, 7)
-        else asyncio.all_tasks(asyncio.get_event_loop())
-    )
+    all_tasks = asyncio.all_tasks(asyncio.get_event_loop())
     for task in all_tasks:
         task.cancel()
 


### PR DESCRIPTION
[Per conversation on forums](https://community.sanicframework.org/t/dropping-python-3-6/793?u=ahopkins) v21.3 will drop Python 3.6 support. 20.12LTS will of course continue to support it.