### PR TITLE
Fix tox for Python3.6 drop support

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = py36, py37, py38, py39, pyNightly, {py36,py37,py38,py39,pyNightly}-no-ext, lint, check, security, docs
+envlist = py37, py38, py39, pyNightly, {py37,py38,py39,pyNightly}-no-ext, lint, check, security, docs
 
 [testenv]
 usedevelop = True
 setenv =
-    {py36,py37,py38,py39,pyNightly}-no-ext: SANIC_NO_UJSON=1
-    {py36,py37,py38,py39,pyNightly}-no-ext: SANIC_NO_UVLOOP=1
+    {py37,py38,py39,pyNightly}-no-ext: SANIC_NO_UJSON=1
+    {py37,py38,py39,pyNightly}-no-ext: SANIC_NO_UVLOOP=1
 deps =
     sanic-testing
     coverage==5.3


### PR DESCRIPTION
Removes Python 3.6 from `tox` testing envs.