### PR TITLE
Codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,7 @@
 coverage:
+  precision: 3
+  round: nearest
+  require_ci_to_pass: no
   status:
     project:
       default:

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,4 +7,4 @@ coverage:
     patch:
       default:
         target: auto
-        threshold: 0.5%
+        threshold: 0.25%

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.5%
+    patch:
+      default:
+        target: auto
+        threshold: 0.5%

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,8 @@
+codecov:
+  require_ci_to_pass: no
 coverage:
   precision: 3
   round: nearest
-  require_ci_to_pass: no
   status:
     project:
       default:


### PR DESCRIPTION
Make codecov a little more lenient. We can allow for the project percentage to vary, and then make codecov a hard passing PR requirement. If something is obviously missing tests, I would expect the PR reviewer to point that out.