### PR TITLE
GIT-1630: add basic signal infra

### DIFF
--- a/sanic/__init__.py
+++ b/sanic/__init__.py
@@ -1,6 +1,8 @@
 from sanic.__version__ import __version__
 from sanic.app import Sanic
 from sanic.blueprints import Blueprint
-
+from sanic.request import Request
+from sanic.response import HTTPResponse
+from sanic import request
 
 __all__ = ["Sanic", "Blueprint", "__version__"]

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -1057,9 +1057,10 @@ class Sanic(BaseSanic):
     async def publish(
         self, signal: str, data: Union[Dict[str, Any], SignalData]
     ):
-        if self.get_signal_context(signal=signal):
+        ctx = self.get_signal_context(signal=signal)
+        if ctx:
             await self._signal_registry.dispatch(
-                context=self.get_signal_context(signal=signal),
+                context=ctx,
                 data=SignalData(additional_info=data)
                 if not isinstance(data, SignalData)
                 else data,

--- a/sanic/base.py
+++ b/sanic/base.py
@@ -2,6 +2,7 @@ from sanic.mixins.exceptions import ExceptionMixin
 from sanic.mixins.listeners import ListenerMixin
 from sanic.mixins.middleware import MiddlewareMixin
 from sanic.mixins.routes import RouteMixin
+from sanic.mixins.signals import SignalMixin
 
 
 class Base(type):
@@ -31,6 +32,7 @@ class BaseSanic(
     MiddlewareMixin,
     ListenerMixin,
     ExceptionMixin,
+    SignalMixin,
     metaclass=Base,
 ):
     ...

--- a/sanic/exceptions.py
+++ b/sanic/exceptions.py
@@ -188,3 +188,11 @@ def abort(status_code, message=None):
         message = message.decode("utf8")
     sanic_exception = _sanic_exceptions.get(status_code, SanicException)
     raise sanic_exception(message=message, status_code=status_code)
+
+
+class SignalsNotFrozenException(SanicException):
+    pass
+
+
+class InvalidSignalFormatException(SanicException):
+    pass

--- a/sanic/mixins/signals.py
+++ b/sanic/mixins/signals.py
@@ -1,18 +1,8 @@
 import typing as t
 
 from sanic.exceptions import InvalidSignalFormatException
-from sanic.signals import SignalRegistry, SignalContext, SignalData
-
-
-class Singleton(type):
-    _instances = {}
-
-    def __call__(cls, *args, **kwargs):
-        if cls not in cls._instances:
-            cls._instances[cls] = super(Singleton, cls).__call__(
-                *args, **kwargs
-            )
-        return cls._instances[cls]
+from sanic.signals import SignalRegistry, SignalContext
+from sanic.utils import Singleton
 
 
 class SignalMixin:

--- a/sanic/mixins/signals.py
+++ b/sanic/mixins/signals.py
@@ -38,7 +38,7 @@ class SignalMixin:
 
         return _wrapper
 
-    def get_signal_context(self, signal: str) -> SignalContext:
+    def get_signal_context(self, signal: str) -> t.Union[None, SignalContext]:
         return self._ctx_mapper.get(signal)
 
     def freeze(self, signal: t.Union[None, str] = None):

--- a/sanic/mixins/signals.py
+++ b/sanic/mixins/signals.py
@@ -21,7 +21,7 @@ class SignalMixin:
     def __init__(self, *args, **kwargs) -> None:
         self._signal_registry = SignalRegistry()
         self._ctx_mapper = {}  # type: t.Dict[str, SignalContext]
-        self.name = None
+        self.name = ""
 
     def signal(self, signal: str):
         def _wrapper(handler: t.Callable):

--- a/sanic/mixins/signals.py
+++ b/sanic/mixins/signals.py
@@ -1,0 +1,60 @@
+import typing as t
+
+from sanic.exceptions import InvalidSignalFormatException
+from sanic.signals import SignalRegistry, SignalContext, SignalData
+
+
+class Singleton(type):
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(
+                *args, **kwargs
+            )
+        return cls._instances[cls]
+
+
+class SignalMixin:
+    __metaclass__ = Singleton
+
+    def __init__(self, *args, **kwargs) -> None:
+        self._signal_registry = SignalRegistry()
+        self._ctx_mapper = {}  # type: t.Dict[str, SignalContext]
+        self.name = None
+
+    def signal(self, signal: str):
+        def _wrapper(handler: t.Callable):
+            parts = signal.split(".")
+            if len(parts) < 2 or len(parts) > 3:
+                raise InvalidSignalFormatException(
+                    message=f"Signal format {signal} is invalid. Supported format is <namespace>.<context>[.<action>]"
+                )
+            else:
+                if not self._ctx_mapper.get(signal):
+                    ctx = SignalContext(
+                        namespace=parts[0],
+                        context=parts[1],
+                        action=parts[2] if len(parts) > 2 else None,
+                    )
+                    self._ctx_mapper[signal] = ctx
+                    self._signal_registry.register(
+                        context=ctx, owner=self.name
+                    )
+                else:
+                    ctx = self._ctx_mapper[signal]
+                self._signal_registry.subscribe(context=ctx, callback=handler)
+            return handler
+
+        return _wrapper
+
+    def get_signal_context(self, signal: str) -> SignalContext:
+        return self._ctx_mapper.get(signal)
+
+    def freeze(self, signal: t.Union[None, str] = None):
+        self._signal_registry.freeze(
+            context=self._ctx_mapper[signal] if signal else None
+        )
+
+    async def publish(self, signal: str, data: t.Dict[str, t.Any]):
+        raise NotImplementedError

--- a/sanic/router.py
+++ b/sanic/router.py
@@ -11,16 +11,19 @@ from sanic_routing.route import Route  # type: ignore
 from sanic.constants import HTTP_METHODS
 from sanic.exceptions import MethodNotSupported, NotFound
 from sanic.request import Request
-
+from sanic.mixins.signals import SignalMixin
 
 ROUTER_CACHE_SIZE = 1024
 
 
-class Router(BaseRouter):
+class Router(BaseRouter, SignalMixin):
     """
     The router implementation responsible for routing a :class:`Request` object
     to the appropriate handler.
     """
+
+    def __init__(self, *args, **kwargs):
+        super(Router, self).__init__(*args, **kwargs)
 
     DEFAULT_METHOD = "GET"
     ALLOWED_METHODS = HTTP_METHODS

--- a/sanic/signals.py
+++ b/sanic/signals.py
@@ -6,19 +6,8 @@ from frozenlist import FrozenList
 
 import sanic
 
-
 from sanic.exceptions import SignalsNotFrozenException
-
-
-class Singleton(type):
-    _instances = {}  # type: t.Dict[type, t.Any]
-
-    def __call__(cls, *args, **kwargs):
-        if cls not in cls._instances:
-            cls._instances[cls] = super(Singleton, cls).__call__(
-                *args, **kwargs
-            )
-        return cls._instances[cls]
+from sanic.utils import Singleton
 
 
 class SignalContext:

--- a/sanic/signals.py
+++ b/sanic/signals.py
@@ -1,0 +1,150 @@
+import typing as t
+
+from inspect import iscoroutinefunction
+from asyncio import AbstractEventLoop
+from frozenlist import FrozenList
+
+import sanic
+
+
+from sanic.exceptions import SignalsNotFrozenException
+
+
+class Singleton(type):
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(
+                *args, **kwargs
+            )
+        return cls._instances[cls]
+
+
+class SignalContext:
+    __slots__ = ["_namespace", "_context", "_action"]
+
+    def __init__(
+        self,
+        namespace: t.AnyStr,
+        context: t.AnyStr,
+        action: t.Union[None, t.AnyStr],
+    ):
+        self._namespace = namespace
+        self._context = context
+        self._action = action
+
+    def __repr__(self):
+        signal_name = f"{self._namespace}.{self._context}"
+        if self._action:
+            signal_name = f"{signal_name}.{self._action}"
+        return signal_name
+
+
+class SignalData:
+    __slots__ = ["_request", "_response", "_additional_info"]
+
+    def __init__(
+        self,
+        request: t.Union[None, "sanic.request.Request"] = None,
+        response: t.Union[None, "sanic.response.HTTPResponse"] = None,
+        additional_info: t.Dict[t.AnyStr, t.Any] = None,
+    ):
+        self._request = request
+        self._response = response
+        self._additional_info = additional_info
+
+    @property
+    def request(self) -> t.Union[None, "sanic.request.Request"]:
+        return self._request
+
+    @property
+    def response(self) -> t.Union[None, "sanic.response.HTTPResponse"]:
+        return self._response
+
+    @property
+    def additional_info(self) -> t.Dict[t.AnyStr, t.Any]:
+        return self._additional_info
+
+    def __repr__(self):
+        info = ""
+        if self._request:
+            info = f"\nRequest(method={self._request.method},url={self._request.url})"
+
+        if self._response:
+            info = f"{info}\nResponse(status={self._response.status})"
+
+        if self._additional_info:
+            info = f"{info}\nAdditional Info({self._additional_info})"
+
+        if info:
+            return info
+        return self
+
+
+class Signal(FrozenList):
+    __slots__ = ("_owner",)
+
+    def __init__(self, owner):
+        super(Signal, self).__init__(items=None)
+        self._owner = owner
+
+    async def dispatch(
+        self,
+        app: "sanic.Sanic",
+        loop: AbstractEventLoop,
+        signal: SignalContext,
+        signal_data: SignalData,
+    ):
+        if not self.frozen:
+            raise SignalsNotFrozenException(
+                message=f"Unable to dispatch events on a non-frozen signal set for source {self._owner}"
+            )
+
+        for recipient in self:
+            if iscoroutinefunction(recipient):
+                await recipient(app, loop, signal, signal_data)
+            else:
+                recipient(app, loop, signal, signal_data)
+
+
+signal_handler = t.Callable[
+    [
+        "sanic.Sanic",
+        AbstractEventLoop,
+        SignalContext,
+        t.Union[None, SignalData],
+    ],
+    t.Union[None, t.Awaitable[None]],
+]
+
+
+class SignalRegistry(metaclass=Singleton):
+    def __init__(self):
+        self._signals_map = {}  # type: t.Dict[SignalContext, Signal]
+
+    def register(self, context: SignalContext, owner: t.AnyStr):
+        self._signals_map[context] = Signal(owner=owner)
+
+    def subscribe(
+        self, context: SignalContext, callback: t.Callable[..., signal_handler]
+    ):
+        self._signals_map[context].append(callback)
+
+    async def dispatch(
+        self,
+        context: SignalContext,
+        data: t.Union[None, SignalData] = None,
+        app: t.Union[None, "sanic.Sanic"] = None,
+        loop: t.Union[None, AbstractEventLoop] = None,
+    ):
+        await self._signals_map[context].dispatch(
+            app=app, loop=loop, signal=context, signal_data=data
+        )
+
+    def freeze(self, context: t.Union[SignalContext, None] = None):
+        if not context:
+            for _ctx, _sig in self._signals_map.items():
+                _sig.freeze()
+        else:
+            self._signals_map[context].freeze()

--- a/sanic/signals.py
+++ b/sanic/signals.py
@@ -77,9 +77,7 @@ class SignalData:
         if self._additional_info:
             info = f"{info}\nAdditional Info({self._additional_info})"
 
-        if info:
-            return info
-        return self
+        return info
 
 
 class Signal(FrozenList):
@@ -122,6 +120,10 @@ signal_handler = t.Callable[
 class SignalRegistry(metaclass=Singleton):
     def __init__(self):
         self._signals_map = {}  # type: t.Dict[SignalContext, Signal]
+
+    @property
+    def signals(self):
+        return self._signals_map
 
     def register(self, context: SignalContext, owner: t.AnyStr):
         self._signals_map[context] = Signal(owner=owner)

--- a/sanic/signals.py
+++ b/sanic/signals.py
@@ -15,13 +15,13 @@ class SignalContext:
 
     def __init__(
         self,
-        namespace: t.AnyStr,
-        context: t.AnyStr,
-        action: t.Union[None, t.AnyStr],
+        namespace: str,
+        context: str,
+        action: t.Union[None, str],
     ):
-        self._namespace = namespace  # type: t.AnyStr
-        self._context = context  # type: t.AnyStr
-        self._action = action  # type: t.Union[None, t.AnyStr]
+        self._namespace = namespace  # type: str
+        self._context = context  # type: str
+        self._action = action  # type: t.Union[None, str]
 
     def __repr__(self):
         signal_name = f"{self._namespace}.{self._context}"
@@ -37,15 +37,15 @@ class SignalData:
         self,
         request: t.Union[None, "sanic.request.Request"] = None,
         response: t.Union[None, "sanic.response.HTTPResponse"] = None,
-        additional_info: t.Dict[t.AnyStr, t.Any] = None,
-    ):
+        additional_info: t.Union[None, t.Dict[str, t.Any]] = None,
+    ) -> None:
         self._request = request  # type: t.Union[None, "sanic.request.Request"]
         self._response = (
             response
         )  # type: t.Union[None, "sanic.response.HTTPResponse"]
         self._additional_info = (
             additional_info
-        )  # type: t.Dict[t.AnyStr, t.Any]
+        )  # type: t.Union[None, t.Dict[str, t.Any]]
 
     @property
     def request(self) -> t.Union[None, "sanic.request.Request"]:
@@ -56,7 +56,7 @@ class SignalData:
         return self._response
 
     @property
-    def additional_info(self) -> t.Dict[t.AnyStr, t.Any]:
+    def additional_info(self) -> t.Union[None, t.Dict[str, t.Any]]:
         return self._additional_info
 
     def __repr__(self):
@@ -76,9 +76,9 @@ class SignalData:
 class Signal(FrozenList):
     __slots__ = ("_owner",)
 
-    def __init__(self, owner):
+    def __init__(self, owner: str):
         super(Signal, self).__init__(items=None)
-        self._owner = owner
+        self._owner = owner  # type: str
 
     async def dispatch(
         self,
@@ -118,7 +118,7 @@ class SignalRegistry(metaclass=Singleton):
     def signals(self) -> t.Dict[SignalContext, Signal]:
         return self._signals_map
 
-    def register(self, context: SignalContext, owner: t.AnyStr) -> None:
+    def register(self, context: SignalContext, owner: str) -> None:
         self._signals_map[context] = Signal(owner=owner)
 
     def subscribe(

--- a/sanic/utils.py
+++ b/sanic/utils.py
@@ -4,7 +4,7 @@ from importlib.util import module_from_spec, spec_from_file_location
 from os import environ as os_environ
 from pathlib import Path
 from re import findall as re_findall
-from typing import Union
+from typing import Union, Dict, Any
 
 from sanic.exceptions import LoadFileException, PyFileError
 from sanic.helpers import import_string
@@ -129,3 +129,14 @@ def load_module_from_file_location(
             return import_string(location)
         except ValueError:
             raise IOError("Unable to load configuration %s" % str(location))
+
+
+class Singleton(type):
+    _instances = {}  # type: Dict[type, Any]
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(
+                *args, **kwargs
+            )
+        return cls._instances[cls]

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ requirements = [
     "aiofiles>=0.6.0",
     "websockets>=8.1,<9.0",
     "multidict>=5.0,<6.0",
+    "frozenlist==1.1.1",
 ]
 
 tests_require = [

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,0 +1,83 @@
+import logging
+from pytest import mark, raises
+
+from sanic.exceptions import SignalsNotFrozenException
+from sanic.signals import SignalRegistry, SignalContext, SignalData
+
+
+class TestSignalsRegistry:
+    def test_singleton_nature(self, signal_registry):
+        assert signal_registry == SignalRegistry()
+
+    def test_signal_registration(self, signal_registry):
+        signal_registry.register(
+            context=SignalContext(
+                namespace="test", context="unittest", action=None
+            ),
+            owner="ut",
+        )
+        ctx = SignalContext(
+            namespace="test", context="unittest", action="success"
+        )
+        signal_registry.register(
+            context=ctx,
+            owner="ut",
+        )
+        signal_registry.freeze(context=ctx)
+        signal_registry.freeze()
+        assert len(signal_registry.signals.keys()) == len(
+            SignalRegistry().signals.keys()
+        )
+
+    @mark.asyncio
+    async def test_signal_dispatch(
+        self, signal_registry, dummy_signal_callback_sync, callback_tracker
+    ):
+        called = 0
+
+        async def _callback(app, loop, signal, data):
+            nonlocal called
+            logger = logging.getLogger()
+            logger.info(f"{data} {signal}")
+            called = 1
+
+        ctx = SignalContext(
+            namespace="test", context="unittest", action="success"
+        )
+        signal_registry.register(
+            context=ctx,
+            owner="ut",
+        )
+        tracker = callback_tracker()
+        signal_registry.subscribe(
+            context=ctx,
+            callback=dummy_signal_callback_sync(call_tracker=tracker),
+        )
+        signal_registry.subscribe(context=ctx, callback=_callback)
+        signal_registry.freeze()
+        await signal_registry.dispatch(
+            context=ctx,
+            data=SignalData(additional_info={"test": "Test"}),
+            app=None,
+            loop=None,
+        )
+        assert called == 1
+
+    @mark.asyncio
+    async def test_failure_for_unfrozen_signal(
+        self,
+        signal_registry,
+        test_signal_context,
+        dummy_signal_callback,
+        callback_tracker,
+    ):
+        data = callback_tracker()
+        signal_registry.register(context=test_signal_context, owner="ut")
+        signal_registry.subscribe(
+            context=test_signal_context,
+            callback=dummy_signal_callback(call_tracker=data),
+        )
+        with raises(expected_exception=SignalsNotFrozenException) as _:
+            await signal_registry.dispatch(
+                context=test_signal_context, data=None
+            )


### PR DESCRIPTION
@ahopkins / @sanic-org/sanic-core-devs  This is in no way an attempt to discard the PR you already have in place, but during my break from all the community, I had a different implementation in mind than my original DRAFT. The migration to `sanic-router` made that way more easier. The whole idea of Mixin is coming to the resume incredibly well. 

This is still an early draft of the changes and if you don't mind, I would like to pick this back up in the coming days as I am trying to get back to the community and a familiar implementation requirement might be a good thing to start with. 

```python
from sanic import Sanic
from sanic.response import json
from sanic.signals import SignalData

from httptools import parse_url

s = Sanic(name="test")

@s.signal("app.route.before")
async def route_before(app, loop, signal, signal_data: SignalData):
    # Having some event generation before the route resolution can help you automatically route your request to a different URL in case of deprecation/Removal of Old APIs
    signal_data.request._parsed_url = parse_url(b"/tests")
    print(f"Route Event {signal_data}")

@s.signal("app.route.missing")
async def invalid_route_event(app, loop, signal, signal_data):
    print(f"Missing {signal_data}")

@s.signal(signal="foo.bar.baz")
async def event_handler(app, loop, signal, signal_data):
    print(f"Signal Received with {signal_data}")

@s.signal(signal="foo.bar.baz")
async def event_handler1(app, loop, signal, signal_data):
    print("Signal Received1 ")

@s.signal(signal="foo.bar.baz")
async def event_handler2(app, loop, signal, signal_data):
    print("Signal Received2")

@s.middleware("request")
async def middleware(reques):
    print("HERE")

@s.route("/get")
async def get(request):
    await s.publish(signal="foo.bar.baz", data={"email": "something@gmail.com"})
    return json({"test": "test"})

s.freeze()
s.run(port=1245, debug=True)
```
## TODO

- [ ] Handle Existing Event Infra for listeners
- [ ] Performance Test to make sure this doesn't add a noticeable overhead
- [ ] Clean exception handling (Possibly indicate what signal dispatch failure can be ignored)
- [ ] If the Signal Dispatch doesn't need to happen in a sequence, run them as async tasks ?
- [ ] Enable Support on the middleware, blueprint and blueprint groups
- [ ] Possible Router level events ?
- [ ] Handle Signal freeze ?
- [ ] Better cache support for signal registry (lru_cache)
- [ ] Async support for `Router.get` might enable much better route even generation?
- [ ] Finalise Custom Event Generation API names 