### PR TITLE
Add __str__ and __repr__ to Sanic and Blueprint

### DIFF
--- a/sanic/base.py
+++ b/sanic/base.py
@@ -33,4 +33,8 @@ class BaseSanic(
     ExceptionMixin,
     metaclass=Base,
 ):
-    ...
+    def __str__(self) -> str:
+        return f"<{self.__class__.__name__} {self.name}>"
+
+    def __repr__(self) -> str:
+        return f'{self.__class__.__name__}(name="{self.name}")'

--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -49,6 +49,23 @@ class Blueprint(BaseSanic):
         self.version = version
         self.strict_slashes = strict_slashes
 
+    def __repr__(self) -> str:
+        args = ", ".join(
+            [
+                f'{attr}="{getattr(self, attr)}"'
+                if isinstance(getattr(self, attr), str)
+                else f"{attr}={getattr(self, attr)}"
+                for attr in (
+                    "name",
+                    "url_prefix",
+                    "host",
+                    "version",
+                    "strict_slashes",
+                )
+            ]
+        )
+        return f"Blueprint({args})"
+
     def route(self, *args, **kwargs):
         kwargs["apply"] = False
         return super().route(*args, **kwargs)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,43 @@
+import pytest
+
+from sanic import Blueprint, Sanic
+
+
+@pytest.fixture
+def app():
+    return Sanic("my_app")
+
+
+@pytest.fixture
+def bp(app):
+    return Blueprint("my_bp")
+
+
+def test_app_str(app):
+    assert str(app) == "<Sanic my_app>"
+
+
+def test_app_repr(app):
+    assert repr(app) == 'Sanic(name="my_app")'
+
+
+def test_bp_str(bp):
+    assert str(bp) == "<Blueprint my_bp>"
+
+
+def test_bp_repr(bp):
+    assert repr(bp) == (
+        'Blueprint(name="my_bp", url_prefix=None, host=None, '
+        "version=None, strict_slashes=None)"
+    )
+
+
+def test_bp_repr_with_values(bp):
+    bp.host = "example.com"
+    bp.url_prefix = "/foo"
+    bp.version = 3
+    bp.strict_slashes = True
+    assert repr(bp) == (
+        'Blueprint(name="my_bp", url_prefix="/foo", host="example.com", '
+        "version=3, strict_slashes=True)"
+    )


### PR DESCRIPTION
I am not sure why we never added something like this earlier.

```
assert str(app) == "<Sanic my_app>"
assert repr(app) == 'Sanic(name="my_app")'
assert str(bp) == "<Blueprint my_bp>"
assert repr(bp) == 'Blueprint(name="my_bp", url_prefix=None, host=None, version=None, strict_slashes=None)'
```