### PR TITLE
[FIX] Allow async trigger handlers to run together on the loop

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -3,7 +3,7 @@ import logging.config
 import os
 import re
 
-from asyncio import CancelledError, Protocol, ensure_future, get_event_loop
+from asyncio import CancelledError, Protocol, ensure_future, gather, get_event_loop
 from asyncio.futures import Future
 from collections import defaultdict, deque
 from functools import partial
@@ -969,10 +969,13 @@ class Sanic(BaseSanic):
         :param events: one or more sync or async functions to execute
         :param loop: event loop
         """
+        awaitables = []
         for event in events:
             result = event(loop)
             if isawaitable(result):
-                await result
+                awaitables.append(result)
+        if awaitables:
+            await gather(*awaitables)
 
     async def _run_request_middleware(self, request, request_name=None):
         # The if improves speed.  I don't know why

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -336,10 +336,13 @@ def trigger_events(events: Optional[Iterable[Callable[..., Any]]], loop):
     :param loop: event loop
     """
     if events:
+        awaitables = []
         for event in events:
             result = event(loop)
             if isawaitable(result):
-                loop.run_until_complete(result)
+                awaitables.append(result)
+        if awaitables:
+            loop.run_until_complete(asyncio.gather(*awaitables))
 
 
 class AsyncioServer:


### PR DESCRIPTION
Allow async trigger handlers to run together on the loop without blocking each other

This is more important now because Signals introduce blocking behavior.