### PR TITLE
Add add_signal method

### DIFF
--- a/sanic/mixins/signals.py
+++ b/sanic/mixins/signals.py
@@ -58,5 +58,14 @@ class SignalMixin:
 
         return decorator
 
+    def add_signal(
+        self,
+        handler,
+        event: str,
+        condition: Dict[str, Any] = None,
+    ):
+        self.signal(event=event, condition=condition)(handler)
+        return handler
+
     def event(self, event: str):
         raise NotImplementedError

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -11,6 +11,15 @@ from sanic.exceptions import InvalidSignal, SanicException
 
 
 def test_add_signal(app):
+    def sync_signal(*_):
+        ...
+
+    app.add_signal(sync_signal, "foo.bar.baz")
+
+    assert len(app.signal_router.routes) == 1
+
+
+def test_add_signal_decorator(app):
     @app.signal("foo.bar.baz")
     def sync_signal(*_):
         ...


### PR DESCRIPTION
We have funcitonal methods for adding routes, middleware, and listeners:

- `app.add_route()`
- `app.register_middleware()`
- `app.register_listener()`

It seems natural to have `add_signal` as well.