### PR TITLE
RFC/1684 Context objects

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -17,6 +17,7 @@ from inspect import isawaitable
 from socket import socket
 from ssl import Purpose, SSLContext, create_default_context
 from traceback import format_exc
+from types import SimpleNamespace
 from typing import (
     Any,
     Awaitable,
@@ -32,6 +33,7 @@ from typing import (
     Union,
 )
 from urllib.parse import urlencode, urlunparse
+from warnings import warn
 
 from sanic_routing.exceptions import FinalizationError  # type: ignore
 from sanic_routing.exceptions import NotFound  # type: ignore
@@ -76,6 +78,42 @@ class Sanic(BaseSanic):
     The main application instance
     """
 
+    __fake_slots__ = (
+        "_asgi_client",
+        "_blueprint_order",
+        "_future_routes",
+        "_future_statics",
+        "_future_middleware",
+        "_future_listeners",
+        "_future_exceptions",
+        "_future_signals",
+        "_test_client",
+        "_test_manager",
+        "asgi",
+        "blueprints",
+        "config",
+        "configure_logging",
+        "ctx",
+        "debug",
+        "error_handler",
+        "go_fast",
+        "is_running",
+        "is_stopping",
+        "listeners",
+        "name",
+        "named_request_middleware",
+        "named_response_middleware",
+        "request_class",
+        "request_middleware",
+        "response_middleware",
+        "router",
+        "signal_router",
+        "sock",
+        "strict_slashes",
+        "websocket_enabled",
+        "websocket_tasks",
+    )
+
     _app_registry: Dict[str, "Sanic"] = {}
     test_mode = False
 
@@ -104,31 +142,33 @@ class Sanic(BaseSanic):
         if configure_logging:
             logging.config.dictConfig(log_config or LOGGING_CONFIG_DEFAULTS)
 
-        self.name = name
-        self.asgi = False
-        self.router = router or Router()
-        self.signal_router = signal_router or SignalRouter()
-        self.request_class = request_class
-        self.error_handler = error_handler or ErrorHandler()
-        self.config = Config(load_env=load_env)
-        self.request_middleware: Deque[MiddlewareType] = deque()
-        self.response_middleware: Deque[MiddlewareType] = deque()
-        self.blueprints: Dict[str, Blueprint] = {}
+        self._asgi_client = None
         self._blueprint_order: List[Blueprint] = []
+        self._test_client = None
+        self._test_manager = None
+        self.asgi = False
+        self.blueprints: Dict[str, Blueprint] = {}
+        self.config = Config(load_env=load_env)
         self.configure_logging = configure_logging
+        self.ctx = SimpleNamespace()
         self.debug = None
-        self.sock = None
-        self.strict_slashes = strict_slashes
-        self.listeners: Dict[str, List[ListenerType]] = defaultdict(list)
-        self.is_stopping = False
+        self.error_handler = error_handler or ErrorHandler()
         self.is_running = False
-        self.websocket_enabled = False
-        self.websocket_tasks: Set[Future] = set()
+        self.is_stopping = False
+        self.listeners: Dict[str, List[ListenerType]] = defaultdict(list)
+        self.name = name
         self.named_request_middleware: Dict[str, Deque[MiddlewareType]] = {}
         self.named_response_middleware: Dict[str, Deque[MiddlewareType]] = {}
-        self._test_manager = None
-        self._test_client = None
-        self._asgi_client = None
+        self.request_class = request_class
+        self.request_middleware: Deque[MiddlewareType] = deque()
+        self.response_middleware: Deque[MiddlewareType] = deque()
+        self.router = router or Router()
+        self.signal_router = signal_router or SignalRouter()
+        self.sock = None
+        self.strict_slashes = strict_slashes
+        self.websocket_enabled = False
+        self.websocket_tasks: Set[Future] = set()
+
         # Register alternative method names
         self.go_fast = self.run
 
@@ -142,6 +182,18 @@ class Sanic(BaseSanic):
 
         if dumps:
             BaseHTTPResponse._dumps = dumps
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        # This is a temporary compat layer so we can raise a warning until
+        # setting attributes on the app instance can be removed and deprecated
+        # with a proper implementation of __slots__
+        if name not in self.__fake_slots__:
+            warn(
+                "Setting variables on application instances is deprecated and "
+                "will be removed in version 21.12. You should change your "
+                f"to use app.ctx.{name} instead."
+            )
+        super().__setattr__(name, value)
 
     @property
     def loop(self):

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -190,8 +190,8 @@ class Sanic(BaseSanic):
         if name not in self.__fake_slots__:
             warn(
                 "Setting variables on application instances is deprecated and "
-                "will be removed in version 21.12. You should change your "
-                f"to use app.ctx.{name} instead."
+                "will be removed in version 21.9. You should change your "
+                f"application to use app.ctx.{name} instead."
             )
         super().__setattr__(name, value)
 

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -33,7 +33,6 @@ from typing import (
     Union,
 )
 from urllib.parse import urlencode, urlunparse
-from warnings import warn
 
 from sanic_routing.exceptions import FinalizationError  # type: ignore
 from sanic_routing.exceptions import NotFound  # type: ignore
@@ -184,18 +183,6 @@ class Sanic(BaseSanic):
 
         if dumps:
             BaseHTTPResponse._dumps = dumps
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        # This is a temporary compat layer so we can raise a warning until
-        # setting attributes on the app instance can be removed and deprecated
-        # with a proper implementation of __slots__
-        if name not in self.__fake_slots__:
-            warn(
-                "Setting variables on application instances is deprecated and "
-                "will be removed in version 21.9. You should change your "
-                f"application to use app.ctx.{name} instead."
-            )
-        super().__setattr__(name, value)
 
     @property
     def loop(self):

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -79,6 +79,7 @@ class Sanic(BaseSanic):
     """
 
     __fake_slots__ = (
+        "_app_registry",
         "_asgi_client",
         "_blueprint_order",
         "_future_routes",
@@ -110,6 +111,7 @@ class Sanic(BaseSanic):
         "signal_router",
         "sock",
         "strict_slashes",
+        "test_mode",
         "websocket_enabled",
         "websocket_tasks",
     )

--- a/sanic/base.py
+++ b/sanic/base.py
@@ -1,3 +1,6 @@
+from typing import Any, Tuple
+from warnings import warn
+
 from sanic.mixins.exceptions import ExceptionMixin
 from sanic.mixins.listeners import ListenerMixin
 from sanic.mixins.middleware import MiddlewareMixin
@@ -35,8 +38,23 @@ class BaseSanic(
     SignalMixin,
     metaclass=Base,
 ):
+    __fake_slots__: Tuple[str, ...]
+
     def __str__(self) -> str:
         return f"<{self.__class__.__name__} {self.name}>"
 
     def __repr__(self) -> str:
         return f'{self.__class__.__name__}(name="{self.name}")'
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        # This is a temporary compat layer so we can raise a warning until
+        # setting attributes on the app instance can be removed and deprecated
+        # with a proper implementation of __slots__
+        if name not in self.__fake_slots__:
+            warn(
+                f"Setting variables on {self.__class__.__name__} instances is "
+                "deprecated and will be removed in version 21.9. You should "
+                f"change your {self.__class__.__name__} instance to use "
+                f"instance.ctx.{name} instead."
+            )
+        super().__setattr__(name, value)

--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -122,8 +122,8 @@ class Blueprint(BaseSanic):
         if name not in self.__fake_slots__:
             warn(
                 "Setting variables on blueprint instances is deprecated and "
-                "will be removed in version 21.12. You should change your "
-                f"to use bp.ctx.{name} instead."
+                "will be removed in version 21.9. You should change your "
+                f"blueprint to use bp.ctx.{name} instead."
             )
         super().__setattr__(name, value)
 

--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -4,17 +4,7 @@ import asyncio
 
 from collections import defaultdict
 from types import SimpleNamespace
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Iterable,
-    List,
-    Optional,
-    Set,
-    Union,
-)
-from warnings import warn
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Set, Union
 
 from sanic_routing.exceptions import NotFound  # type: ignore
 from sanic_routing.route import Route  # type: ignore
@@ -114,18 +104,6 @@ class Blueprint(BaseSanic):
             ]
         )
         return f"Blueprint({args})"
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        # This is a temporary compat layer so we can raise a warning until
-        # setting attributes on the app instance can be removed and deprecated
-        # with a proper implementation of __slots__
-        if name not in self.__fake_slots__:
-            warn(
-                "Setting variables on blueprint instances is deprecated and "
-                "will be removed in version 21.9. You should change your "
-                f"blueprint to use bp.ctx.{name} instead."
-            )
-        super().__setattr__(name, value)
 
     @property
     def apps(self):

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -82,6 +82,7 @@ class Request:
         "_ip",
         "_parsed_url",
         "_port",
+        "_protocol",
         "_remote_addr",
         "_socket",
         "_match_info",
@@ -153,6 +154,7 @@ class Request:
         self.stream: Optional[Http] = None
         self.endpoint: Optional[str] = None
         self.route: Optional[Route] = None
+        self._protocol = None
 
     def __repr__(self):
         class_name = self.__class__.__name__
@@ -204,6 +206,12 @@ class Request:
         """
         if not self.body:
             self.body = b"".join([data async for data in self.stream])
+
+    @property
+    def connection(self):
+        if not self._protocol:
+            self._protocol = self.transport.get_protocol()
+        return self._protocol
 
     @property
     def raw_headers(self):

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -211,6 +211,8 @@ class Request:
     def connection(self):
         if not self._protocol:
             self._protocol = self.transport.get_protocol()
+            if not hasattr(self._protocol, "ctx"):
+                self._protocol.ctx = SimpleNamespace()
         return self._protocol
 
     @property

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -208,11 +208,9 @@ class Request:
             self.body = b"".join([data async for data in self.stream])
 
     @property
-    def connection(self):
+    def protocol(self):
         if not self._protocol:
             self._protocol = self.transport.get_protocol()
-            if not hasattr(self._protocol, "ctx"):
-                self._protocol.ctx = SimpleNamespace()
         return self._protocol
 
     @property

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -288,7 +288,6 @@ class HttpProtocol(asyncio.Protocol):
         try:
             # TODO: Benchmark to find suitable write buffer limits
             transport.set_write_buffer_limits(low=16384, high=65536)
-            # if not hasattr(transport, "ctx"):
             self.ctx = SimpleNamespace()
             self.connections.add(self)
             self.transport = transport

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from ssl import SSLContext
-from types import SimpleNamespace
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -288,7 +287,6 @@ class HttpProtocol(asyncio.Protocol):
         try:
             # TODO: Benchmark to find suitable write buffer limits
             transport.set_write_buffer_limits(low=16384, high=65536)
-            self.ctx = SimpleNamespace()
             self.connections.add(self)
             self.transport = transport
             self._task = self.loop.create_task(self.connection_task())

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from ssl import SSLContext
+from types import SimpleNamespace
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -62,24 +63,28 @@ class ConnInfo:
     """
 
     __slots__ = (
-        "sockname",
-        "peername",
-        "server",
-        "server_port",
-        "client",
         "client_port",
+        "client",
+        "ctx",
+        "peername",
+        "server_port",
+        "server",
+        "sockname",
         "ssl",
     )
 
     def __init__(self, transport: TransportProtocol, unix=None):
-        self.ssl: bool = bool(transport.get_extra_info("sslcontext"))
+        self.ctx = SimpleNamespace()
+        self.peername = None
         self.server = self.client = ""
         self.server_port = self.client_port = 0
-        self.peername = None
         self.sockname = addr = transport.get_extra_info("sockname")
+        self.ssl: bool = bool(transport.get_extra_info("sslcontext"))
+
         if isinstance(addr, str):  # UNIX socket
             self.server = unix or addr
             return
+
         # IPv4 (ip, port) or IPv6 (ip, port, flowinfo, scopeid)
         if isinstance(addr, tuple):
             self.server = addr[0] if len(addr) == 2 else f"[{addr[0]}]"
@@ -88,6 +93,7 @@ class ConnInfo:
             if addr[1] != (443 if self.ssl else 80):
                 self.server = f"{self.server}:{addr[1]}"
         self.peername = addr = transport.get_extra_info("peername")
+
         if isinstance(addr, tuple):
             self.client = addr[0] if len(addr) == 2 else f"[{addr[0]}]"
             self.client_port = addr[1]

--- a/sanic/server.py
+++ b/sanic/server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from ssl import SSLContext
+from types import SimpleNamespace
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -107,6 +108,7 @@ class HttpProtocol(asyncio.Protocol):
         "connections",
         "signal",
         "conn_info",
+        "ctx",
         # request params
         "request",
         # request config
@@ -286,6 +288,8 @@ class HttpProtocol(asyncio.Protocol):
         try:
             # TODO: Benchmark to find suitable write buffer limits
             transport.set_write_buffer_limits(low=16384, high=65536)
+            # if not hasattr(transport, "ctx"):
+            self.ctx = SimpleNamespace()
             self.connections.add(self)
             self.transport = transport
             self._task = self.loop.create_task(self.connection_task())

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -380,9 +380,9 @@ def test_app_set_attribute_warning(app):
 
     assert len(record) == 1
     assert record[0].message.args[0] == (
-        "Setting variables on application instances is deprecated "
+        "Setting variables on Sanic instances is deprecated "
         "and will be removed in version 21.9. You should change your "
-        "application to use app.ctx.foo instead."
+        "Sanic instance to use instance.ctx.foo instead."
     )
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -372,3 +372,22 @@ def test_app_no_registry_env():
     ):
         Sanic.get_app("no-register")
     del environ["SANIC_REGISTER"]
+
+
+def test_app_set_attribute_warning(app):
+    with pytest.warns(UserWarning) as record:
+        app.foo = 1
+
+    assert len(record) == 1
+    assert record[0].message.args[0] == (
+        "Setting variables on application instances is deprecated "
+        "and will be removed in version 21.9. You should change your "
+        "application to use app.ctx.foo instead."
+    )
+
+
+def test_app_set_context(app):
+    app.ctx.foo = 1
+
+    retrieved = Sanic.get_app(app.name)
+    assert retrieved.ctx.foo == 1

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -1033,7 +1033,7 @@ def test_bp_set_attribute_warning():
 
     assert len(record) == 1
     assert record[0].message.args[0] == (
-        "Setting variables on blueprint instances is deprecated "
+        "Setting variables on Blueprint instances is deprecated "
         "and will be removed in version 21.9. You should change your "
-        "blueprint to use bp.ctx.foo instead."
+        "Blueprint instance to use instance.ctx.foo instead."
     )

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -1024,3 +1024,16 @@ def test_blueprint_registered_multiple_apps():
     for app in (app1, app2):
         _, response = app.test_client.get("/")
         assert response.text == f"{app.name}.bp.handler"
+
+
+def test_bp_set_attribute_warning():
+    bp = Blueprint("bp")
+    with pytest.warns(UserWarning) as record:
+        bp.foo = 1
+
+    assert len(record) == 1
+    assert record[0].message.args[0] == (
+        "Setting variables on blueprint instances is deprecated "
+        "and will be removed in version 21.9. You should change your "
+        "blueprint to use bp.ctx.foo instead."
+    )

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -5,6 +5,7 @@ import pytest
 
 from sanic import Sanic, response
 from sanic.request import Request, uuid
+from sanic.server import HttpProtocol
 
 
 def test_no_request_id_not_called(monkeypatch):
@@ -83,3 +84,18 @@ def test_route_assigned_to_request(app):
 
     request, _ = app.test_client.get("/")
     assert request.route is list(app.router.routes.values())[0]
+
+
+def test_protocol_attribute(app):
+    retrieved = None
+
+    @app.get("/")
+    async def get(request):
+        nonlocal retrieved
+        retrieved = request.protocol
+        return response.empty()
+
+    headers = {"Connection": "keep-alive"}
+    _ = app.test_client.get("/", headers=headers)
+
+    assert isinstance(retrieved, HttpProtocol)


### PR DESCRIPTION
Resolves #1684 

The proposal is to add a `request.ctx` like API to Sanic applications, blueprints, and connection objects.

A common practice is to add arbitrary objects on the Sanic app instance. This introduces a `__fake_slots__` that is meant to be replaced by a real `__slots__` in the future. In the meantime, we will check and raise a warning to direct the developer to using `app.ctx`.

---

Perhaps the more exciting introduction is `request.connection.ctx`.

This object will remain alive so long as a single transport is kept open. Since the `KEEP_ALIVE` will not close a transport layer, we can leverage that to place a context object on it.

A practical benefit of this might be only needing to check authentication or perform some expensive operation once for several calls.
