### PR TITLE
fix?: recursion error on Sanic subclass initialisation

### DIFF
--- a/sanic/base.py
+++ b/sanic/base.py
@@ -16,9 +16,7 @@ class Base(type):
             nonlocal init
             nonlocal name
 
-            bases = [
-                b for base in type(self).__bases__ for b in base.__bases__
-            ]
+            bases = BaseSanic.__bases__
 
             for base in bases:
                 base.__init__(self, *args, **kwargs)

--- a/sanic/base.py
+++ b/sanic/base.py
@@ -8,35 +8,18 @@ from sanic.mixins.routes import RouteMixin
 from sanic.mixins.signals import SignalMixin
 
 
-class Base(type):
-    def __new__(cls, name, bases, attrs):
-        init = attrs.get("__init__")
-
-        def __init__(self, *args, **kwargs):
-            nonlocal init
-            nonlocal name
-
-            bases = BaseSanic.__bases__
-
-            for base in bases:
-                base.__init__(self, *args, **kwargs)
-
-            if init:
-                init(self, *args, **kwargs)
-
-        attrs["__init__"] = __init__
-        return type.__new__(cls, name, bases, attrs)
-
-
 class BaseSanic(
     RouteMixin,
     MiddlewareMixin,
     ListenerMixin,
     ExceptionMixin,
     SignalMixin,
-    metaclass=Base,
 ):
     __fake_slots__: Tuple[str, ...]
+
+    def __init__(self, *args, **kwargs) -> None:
+        for base in BaseSanic.__bases__:
+            base.__init__(self, *args, **kwargs)  # type: ignore
 
     def __str__(self) -> str:
         return f"<{self.__class__.__name__} {self.name}>"

--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -73,6 +73,7 @@ class Blueprint(BaseSanic):
         version: Optional[int] = None,
         strict_slashes: Optional[bool] = None,
     ):
+        super().__init__()
 
         self._apps: Set[Sanic] = set()
         self.ctx = SimpleNamespace()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -405,3 +405,10 @@ def test_app_set_context(app):
 
     retrieved = Sanic.get_app(app.name)
     assert retrieved.ctx.foo == 1
+
+
+def test_subclass_initialisation():
+    class CustomSanic(Sanic):
+        pass
+
+    CustomSanic("test_subclass_initialisation")


### PR DESCRIPTION
Fixes #2073

Needs someone to take a look at it, not super familiar with `__new__`,

but it seems to fix the error and work as expected