### PR TITLE
Perf improv

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -752,9 +752,9 @@ class Sanic(BaseSanic):
     ):
         request.app = self
         if not getattr(handler, "__blueprintname__", False):
-            request.endpoint = handler.__name__
+            request._name = handler.__name__
         else:
-            request.endpoint = (
+            request._name = (
                 getattr(handler, "__blueprintname__", "") + handler.__name__
             )
 

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -676,27 +676,23 @@ class Sanic(BaseSanic):
         response = None
         try:
             # Fetch handler from router
-            (
-                route,
-                handler,
-                kwargs,
-            ) = self.router.get(request)
+            route, handler, kwargs = self.router.get(
+                request.path, request.method, request.headers.get("host")
+            )
 
             request._match_info = kwargs
             request.route = route
-            request.name = route.name
-            request.uri_template = f"/{route.path}"
-            request.endpoint = request.name
 
             if (
-                request.stream
-                and request.stream.request_body
+                request.stream.request_body  # type: ignore
                 and not route.ctx.ignore_body
             ):
 
                 if hasattr(handler, "is_stream"):
                     # Streaming handler: lift the size limit
-                    request.stream.request_max_size = float("inf")
+                    request.stream.request_max_size = float(  # type: ignore
+                        "inf"
+                    )
                 else:
                     # Non-streaming handler: preload body
                     await request.receive_body()
@@ -730,8 +726,7 @@ class Sanic(BaseSanic):
             if response:
                 response = await request.respond(response)
             else:
-                if request.stream:
-                    response = request.stream.response
+                response = request.stream.response  # type: ignore
             # Make sure that response is finished / run StreamingHTTP callback
 
             if isinstance(response, BaseHTTPResponse):

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -90,11 +90,9 @@ class Request:
         "body",
         "conn_info",
         "ctx",
-        "endpoint",
         "head",
         "headers",
         "method",
-        "name",
         "parsed_args",
         "parsed_not_grouped_args",
         "parsed_files",
@@ -106,7 +104,6 @@ class Request:
         "route",
         "stream",
         "transport",
-        "uri_template",
         "version",
     )
 
@@ -136,7 +133,6 @@ class Request:
         self.body = b""
         self.conn_info: Optional[ConnInfo] = None
         self.ctx = SimpleNamespace()
-        self.name: Optional[str] = None
         self.parsed_forwarded: Optional[Options] = None
         self.parsed_json = None
         self.parsed_form = None
@@ -147,12 +143,10 @@ class Request:
         self.parsed_not_grouped_args: DefaultDict[
             Tuple[bool, bool, str, str], List[Tuple[str, str]]
         ] = defaultdict(list)
-        self.uri_template: Optional[str] = None
         self.request_middleware_started = False
         self._cookies: Optional[Dict[str, str]] = None
         self._match_info: Dict[str, Any] = {}
         self.stream: Optional[Http] = None
-        self.endpoint: Optional[str] = None
         self.route: Optional[Route] = None
         self._protocol = None
 
@@ -206,6 +200,18 @@ class Request:
         """
         if not self.body:
             self.body = b"".join([data async for data in self.stream])
+
+    @property
+    def name(self):
+        return self.route.name
+
+    @property
+    def endpoint(self):
+        return self.route.name
+
+    @property
+    def uri_template(self):
+        return f"/{self.route.path}"
 
     @property
     def protocol(self):

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -86,6 +86,7 @@ class Request:
         "_remote_addr",
         "_socket",
         "_match_info",
+        "_name",
         "app",
         "body",
         "conn_info",
@@ -121,6 +122,7 @@ class Request:
         # TODO: Content-Encoding detection
         self._parsed_url = parse_url(url_bytes)
         self._id: Optional[Union[uuid.UUID, str, int]] = None
+        self._name: Optional[str] = None
         self.app = app
 
         self.headers = headers
@@ -203,11 +205,15 @@ class Request:
 
     @property
     def name(self):
-        return self.route.name
+        if self._name:
+            return self._name
+        elif self.route:
+            return self.route.name
+        return None
 
     @property
     def endpoint(self):
-        return self.route.name
+        return self.name
 
     @property
     def uri_template(self):

--- a/sanic/router.py
+++ b/sanic/router.py
@@ -11,7 +11,6 @@ from sanic_routing.route import Route  # type: ignore
 from sanic.constants import HTTP_METHODS
 from sanic.exceptions import MethodNotSupported, NotFound, SanicException
 from sanic.models.handler_types import RouteHandler
-from sanic.request import Request
 
 
 ROUTER_CACHE_SIZE = 1024

--- a/sanic/router.py
+++ b/sanic/router.py
@@ -27,16 +27,11 @@ class Router(BaseRouter):
     DEFAULT_METHOD = "GET"
     ALLOWED_METHODS = HTTP_METHODS
 
-    # Putting the lru_cache on Router.get() performs better for the benchmarsk
-    # at tests/benchmark/test_route_resolution_benchmark.py
-    # However, overall application performance is significantly improved
-    # with the lru_cache on this method.
-    @lru_cache(maxsize=ROUTER_CACHE_SIZE)
     def _get(
-        self, path, method, host
+        self, path: str, method: str, host: Optional[str]
     ) -> Tuple[Route, RouteHandler, Dict[str, Any]]:
         try:
-            route, handler, params = self.resolve(
+            return self.resolve(
                 path=path,
                 method=method,
                 extra={"host": host},
@@ -50,14 +45,9 @@ class Router(BaseRouter):
                 allowed_methods=e.allowed_methods,
             )
 
-        return (
-            route,
-            handler,
-            params,
-        )
-
+    @lru_cache(maxsize=ROUTER_CACHE_SIZE)
     def get(  # type: ignore
-        self, request: Request
+        self, path: str, method: str, host: Optional[str]
     ) -> Tuple[Route, RouteHandler, Dict[str, Any]]:
         """
         Retrieve a `Route` object containg the details about how to handle
@@ -69,9 +59,7 @@ class Router(BaseRouter):
             correct response
         :rtype: Tuple[ Route, RouteHandler, Dict[str, Any]]
         """
-        return self._get(
-            request.path, request.method, request.headers.get("host")
-        )
+        return self._get(path, method, host)
 
     def add(  # type: ignore
         self,

--- a/tests/benchmark/test_route_resolution_benchmark.py
+++ b/tests/benchmark/test_route_resolution_benchmark.py
@@ -23,18 +23,21 @@ class TestSanicRouteResolution:
         )
         router, simple_routes = sanic_router(route_details=simple_routes)
         route_to_call = choice(simple_routes)
+        request = Request(
+            "/{}".format(route_to_call[-1]).encode(),
+            {"host": "localhost"},
+            "v1",
+            route_to_call[0],
+            None,
+            None,
+        )
 
         result = benchmark.pedantic(
             router.get,
             (
-                Request(
-                    "/{}".format(route_to_call[-1]).encode(),
-                    {"host": "localhost"},
-                    "v1",
-                    route_to_call[0],
-                    None,
-                    None,
-                ),
+                request.path,
+                request.method,
+                request.headers.get("host"),
             ),
             iterations=1000,
             rounds=1000,
@@ -56,18 +59,21 @@ class TestSanicRouteResolution:
         )
 
         print("{} -> {}".format(route_to_call[-1], url))
+        request = Request(
+            "/{}".format(url).encode(),
+            {"host": "localhost"},
+            "v1",
+            route_to_call[0],
+            None,
+            None,
+        )
 
         result = benchmark.pedantic(
             router.get,
             (
-                Request(
-                    "/{}".format(url).encode(),
-                    {"host": "localhost"},
-                    "v1",
-                    route_to_call[0],
-                    None,
-                    None,
-                ),
+                request.path,
+                request.method,
+                request.headers.get("host"),
             ),
             iterations=1000,
             rounds=1000,

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -35,6 +35,27 @@ def test_request_id_defaults_uuid():
     assert request.id == request.id == request._id
 
 
+def test_name_none():
+    request = Request(b"/", {}, None, "GET", None, None)
+
+    assert request.name is None
+
+
+def test_name_from_route():
+    request = Request(b"/", {}, None, "GET", None, None)
+    route = Mock()
+    request.route = route
+
+    assert request.name == route.name
+
+
+def test_name_from_set():
+    request = Request(b"/", {}, None, "GET", None, None)
+    request._name = "foo"
+
+    assert request.name == "foo"
+
+
 @pytest.mark.parametrize(
     "request_id,expected_type",
     (

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -166,7 +166,9 @@ def test_matching(path, headers, expected):
     request = Request(path, headers, None, "GET", None, app)
 
     try:
-        app.router.get(request=request)
+        app.router.get(
+            request.path, request.method, request.headers.get("host")
+        )
     except NotFound:
         response = 404
     except Exception:


### PR DESCRIPTION
I was playing around with some benchmarking and started to notice that we were not realizing the performance bump that I was expecting.

`v20.12`
```
Running 10s test @ http://localhost:3000
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     3.60ms    3.62ms  77.03ms   92.43%
    Req/Sec    10.73k     2.71k   26.83k    79.17%
  1281439 requests in 10.05s, 144.20MB read
Requests/sec: 127460.90
Transfer/sec:     14.34MB
```

`master`
```
Running 10s test @ http://localhost:3000
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     3.63ms    4.25ms  87.71ms   92.34%
    Req/Sec    11.33k     2.63k   52.29k    84.13%
  1343733 requests in 10.08s, 131.99MB read
Requests/sec: 133339.69
Transfer/sec:     13.10MB
```

I realized that this is mainly due to some minor issues in `handle_request`. With these small changes:

`perf-improv`
```
Running 10s test @ http://localhost:3000
  12 threads and 400 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     3.58ms    4.12ms  88.78ms   92.44%
    Req/Sec    11.49k     2.40k   50.72k    77.39%
  1376168 requests in 10.10s, 135.18MB read
Requests/sec: 136254.12
Transfer/sec:     13.38MB
```

There are some more gains to be had here, but not until 21.6 and a more thorough overhaul of this method.