### PR TITLE
Disable response timeout on websocket connections

### DIFF
--- a/sanic/server.py
+++ b/sanic/server.py
@@ -234,11 +234,16 @@ class HttpProtocol(asyncio.Protocol):
             if stage is Stage.IDLE and duration > self.keep_alive_timeout:
                 logger.debug("KeepAlive Timeout. Closing connection.")
             elif stage is Stage.REQUEST and duration > self.request_timeout:
+                logger.debug("Request Timeout. Closing connection.")
                 self._http.exception = RequestTimeout("Request Timeout")
+            elif stage is Stage.HANDLER and self._http.upgrade_websocket:
+                logger.debug("Handling websocket. Timeouts disabled.")
+                return
             elif (
                 stage in (Stage.HANDLER, Stage.RESPONSE, Stage.FAILED)
                 and duration > self.response_timeout
             ):
+                logger.debug("Response Timeout. Closing connection.")
                 self._http.exception = ServiceUnavailable("Response Timeout")
             else:
                 interval = (

--- a/tests/test_response_timeout.py
+++ b/tests/test_response_timeout.py
@@ -80,7 +80,6 @@ def test_response_handler_cancelled():
     assert response_handler_cancelled_app.ctx.flag is False
 
 
-# @pytest.mark.asyncio
 def test_response_timeout_not_applied():
     _ = response_ws_app.test_client.websocket("/ws")
     assert response_ws_app.ctx.event.is_set()

--- a/tests/test_response_timeout.py
+++ b/tests/test_response_timeout.py
@@ -1,5 +1,7 @@
 import asyncio
 
+from time import sleep
+
 from sanic import Sanic
 from sanic.exceptions import ServiceUnavailable
 from sanic.response import text
@@ -8,10 +10,15 @@ from sanic.response import text
 response_timeout_app = Sanic("test_response_timeout")
 response_timeout_default_app = Sanic("test_response_timeout_default")
 response_handler_cancelled_app = Sanic("test_response_handler_cancelled")
+response_ws_app = Sanic("response_ws_app")
 
 response_timeout_app.config.RESPONSE_TIMEOUT = 1
 response_timeout_default_app.config.RESPONSE_TIMEOUT = 1
 response_handler_cancelled_app.config.RESPONSE_TIMEOUT = 1
+response_ws_app.config.RESPONSE_TIMEOUT = 1
+
+response_ws_app.ctx.event = asyncio.Event()
+response_handler_cancelled_app.ctx.flag = False
 
 
 @response_timeout_app.route("/1")
@@ -20,15 +27,16 @@ async def handler_1(request):
     return text("OK")
 
 
+@response_ws_app.websocket("/ws")
+async def ws_handler(request, ws):
+    sleep(2)
+    await asyncio.sleep(0)
+    request.app.ctx.event.set()
+
+
 @response_timeout_app.exception(ServiceUnavailable)
 def handler_exception(request, exception):
     return text("Response Timeout from error_handler.", 503)
-
-
-def test_server_error_response_timeout():
-    request, response = response_timeout_app.test_client.get("/1")
-    assert response.status == 503
-    assert response.text == "Response Timeout from error_handler."
 
 
 @response_timeout_default_app.route("/1")
@@ -37,20 +45,11 @@ async def handler_2(request):
     return text("OK")
 
 
-def test_default_server_error_response_timeout():
-    request, response = response_timeout_default_app.test_client.get("/1")
-    assert response.status == 503
-    assert "Response Timeout" in response.text
-
-
-response_handler_cancelled_app.flag = False
-
-
 @response_handler_cancelled_app.exception(asyncio.CancelledError)
 def handler_cancelled(request, exception):
     # If we get a CancelledError, it means sanic has already sent a response,
     # we should not ever have to handle a CancelledError.
-    response_handler_cancelled_app.flag = True
+    response_handler_cancelled_app.ctx.flag = True
     return text("App received CancelledError!", 500)
     # The client will never receive this response, because the socket
     # is already closed when we get a CancelledError.
@@ -62,8 +61,26 @@ async def handler_3(request):
     return text("OK")
 
 
+def test_server_error_response_timeout():
+    request, response = response_timeout_app.test_client.get("/1")
+    assert response.status == 503
+    assert response.text == "Response Timeout from error_handler."
+
+
+def test_default_server_error_response_timeout():
+    request, response = response_timeout_default_app.test_client.get("/1")
+    assert response.status == 503
+    assert "Response Timeout" in response.text
+
+
 def test_response_handler_cancelled():
     request, response = response_handler_cancelled_app.test_client.get("/1")
     assert response.status == 503
     assert "Response Timeout" in response.text
-    assert response_handler_cancelled_app.flag is False
+    assert response_handler_cancelled_app.ctx.flag is False
+
+
+# @pytest.mark.asyncio
+def test_response_timeout_not_applied():
+    _ = response_ws_app.test_client.websocket("/ws")
+    assert response_ws_app.ctx.event.is_set()


### PR DESCRIPTION
Fixes #2078 

This is only a bandaid. I think that when we address #2000 we might need to do something different here. Either incrementing the time or somehow merging the response timeout with the `WEBSOCKET_PING_TIMEOUT`.