### PR TITLE
review: use plural for MiddlewareMixin._future_middlewares

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -83,7 +83,7 @@ class Sanic(BaseSanic):
         "_blueprint_order",
         "_future_routes",
         "_future_statics",
-        "_future_middleware",
+        "_future_middlewares",
         "_future_listeners",
         "_future_exceptions",
         "_future_signals",

--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -47,7 +47,7 @@ class Blueprint(BaseSanic):
         "_apps",
         "_future_routes",
         "_future_statics",
-        "_future_middleware",
+        "_future_middlewares",
         "_future_listeners",
         "_future_exceptions",
         "_future_signals",
@@ -238,7 +238,7 @@ class Blueprint(BaseSanic):
 
         # Middleware
         if route_names:
-            for future in self._future_middleware:
+            for future in self._future_middlewares:
                 middleware.append(app._apply_middleware(future, route_names))
 
         # Exceptions

--- a/sanic/mixins/middleware.py
+++ b/sanic/mixins/middleware.py
@@ -6,7 +6,7 @@ from sanic.models.futures import FutureMiddleware
 
 class MiddlewareMixin:
     def __init__(self, *args, **kwargs) -> None:
-        self._future_middleware: List[FutureMiddleware] = []
+        self._future_middlewares: List[FutureMiddleware] = []
 
     def _apply_middleware(self, middleware: FutureMiddleware):
         raise NotImplementedError  # noqa
@@ -30,7 +30,7 @@ class MiddlewareMixin:
             nonlocal apply
 
             future_middleware = FutureMiddleware(middleware, attach_to)
-            self._future_middleware.append(future_middleware)
+            self._future_middlewares.append(future_middleware)
             if apply:
                 self._apply_middleware(future_middleware)
             return middleware


### PR DESCRIPTION
Convert `MiddlewareMixin._future_middleware` to `MiddlewareMixin._future_middlewares`. Using the plural make it consistent with variable names in other Mixins.