### PR TITLE
FIX UserWarning when using ASGI mode

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -78,6 +78,7 @@ class Sanic(BaseSanic):
     """
 
     __fake_slots__ = (
+        "_asgi_app",
         "_app_registry",
         "_asgi_client",
         "_blueprint_order",


### PR DESCRIPTION
get rid of warning when using ASGI server to run sanic.

```sh
INFO:     Started server process [69183]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://127.0.0.1:8000 (Press CTRL+C to quit)
./sanic/base.py:35: UserWarning: Setting variables on Sanic instances is deprecated and will be removed in version 21.9. You should change your Sanic instance to use instance.ctx._asgi_app instead.
  warn(
...
```