### PR TITLE
Consistent use of error loggers

### DIFF
--- a/sanic/__main__.py
+++ b/sanic/__main__.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional
 from sanic import __version__
 from sanic.app import Sanic
 from sanic.config import BASE_LOGO
-from sanic.log import logger
+from sanic.log import error_logger
 
 
 class SanicArgumentParser(ArgumentParser):
@@ -119,13 +119,13 @@ def main():
             ssl=ssl,
         )
     except ImportError as e:
-        logger.error(
+        error_logger.error(
             f"No module named {e.name} found.\n"
             f"  Example File: project/sanic_server.py -> app\n"
             f"  Example Module: project.sanic_server.app"
         )
     except ValueError:
-        logger.exception("Failed to run app")
+        error_logger.exception("Failed to run app")
 
 
 if __name__ == "__main__":

--- a/sanic/handlers.py
+++ b/sanic/handlers.py
@@ -6,7 +6,7 @@ from sanic.exceptions import (
     HeaderNotFound,
     InvalidRangeType,
 )
-from sanic.log import logger
+from sanic.log import error_logger
 from sanic.response import text
 
 
@@ -101,7 +101,7 @@ class ErrorHandler:
             response_message = (
                 "Exception raised in exception handler " '"%s" for uri: %s'
             )
-            logger.exception(response_message, handler.__name__, url)
+            error_logger.exception(response_message, handler.__name__, url)
 
             if self.debug:
                 return text(response_message % (handler.__name__, url), 500)
@@ -137,7 +137,9 @@ class ErrorHandler:
                 url = "unknown"
 
             self.log(format_exc())
-            logger.exception("Exception occurred while handling uri: %s", url)
+            error_logger.exception(
+                "Exception occurred while handling uri: %s", url
+            )
 
         return exception_response(request, exception, self.debug)
 

--- a/sanic/http.py
+++ b/sanic/http.py
@@ -20,7 +20,7 @@ from sanic.exceptions import (
 )
 from sanic.headers import format_http1_response
 from sanic.helpers import has_message_body
-from sanic.log import access_logger, logger
+from sanic.log import access_logger, error_logger, logger
 
 
 class Stage(Enum):
@@ -143,7 +143,7 @@ class Http:
             # Try to consume any remaining request body
             if self.request_body:
                 if self.response and 200 <= self.response.status < 300:
-                    logger.error(f"{self.request} body not consumed.")
+                    error_logger.error(f"{self.request} body not consumed.")
 
                 try:
                     async for _ in self:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -276,7 +276,7 @@ def test_handle_request_with_nested_sanic_exception(app, monkeypatch, caplog):
     assert response.status == 500
     assert "Mock SanicException" in response.text
     assert (
-        "sanic.root",
+        "sanic.error",
         logging.ERROR,
         f"Exception occurred while handling uri: 'http://127.0.0.1:{port}/'",
     ) in caplog.record_tuples

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -113,9 +113,9 @@ def test_logging_pass_customer_logconfig():
 def test_log_connection_lost(app, debug, monkeypatch):
     """ Should not log Connection lost exception on non debug """
     stream = StringIO()
-    root = logging.getLogger("sanic.root")
-    root.addHandler(logging.StreamHandler(stream))
-    monkeypatch.setattr(sanic.server, "logger", root)
+    error = logging.getLogger("sanic.error")
+    error.addHandler(logging.StreamHandler(stream))
+    monkeypatch.setattr(sanic.server, "error_logger", error)
 
     @app.route("/conn_lost")
     async def conn_lost(request):

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -156,7 +156,7 @@ def test_middleware_response_raise_cancelled_error(app, caplog):
 
         assert response.status == 503
         assert (
-            "sanic.root",
+            "sanic.error",
             logging.ERROR,
             "Exception occurred while handling uri: 'http://127.0.0.1:42101/'",
         ) not in caplog.record_tuples
@@ -174,7 +174,7 @@ def test_middleware_response_raise_exception(app, caplog):
     assert response.status == 404
     # 404 errors are not logged
     assert (
-        "sanic.root",
+        "sanic.error",
         logging.ERROR,
         "Exception occurred while handling uri: 'http://127.0.0.1:42101/'",
     ) not in caplog.record_tuples


### PR DESCRIPTION
Some exceptions and errors were handled by the default logging handler. I changed this, so every `.exception()` and `.error()` is actually handled by the `sanic.error` handler instead of the `sanic.root` handler.
(see https://community.sanicframework.org/t/inconsistent-use-of-loggers/834)