### PR TITLE
Fix request.args.pop removes parameters inconsistently

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -378,9 +378,12 @@ class Request:
         :type errors: str
         :return: RequestParameters
         """
-        if not self.parsed_args[
-            (keep_blank_values, strict_parsing, encoding, errors)
-        ]:
+        if (
+            keep_blank_values,
+            strict_parsing,
+            encoding,
+            errors,
+        ) not in self.parsed_args:
             if self.query_string:
                 self.parsed_args[
                     (keep_blank_values, strict_parsing, encoding, errors)
@@ -434,9 +437,12 @@ class Request:
         :type errors: str
         :return: list
         """
-        if not self.parsed_not_grouped_args[
-            (keep_blank_values, strict_parsing, encoding, errors)
-        ]:
+        if (
+            keep_blank_values,
+            strict_parsing,
+            encoding,
+            errors,
+        ) not in self.parsed_not_grouped_args:
             if self.query_string:
                 self.parsed_not_grouped_args[
                     (keep_blank_values, strict_parsing, encoding, errors)

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -291,6 +291,17 @@ def test_query_string(app):
     assert request.args.getlist("test1") == ["1"]
     assert request.args.get("test3", default="My value") == "My value"
 
+def test_popped_stays_popped(app):
+    @app.route("/")
+    async def handler(request):
+        return text("OK")
+
+    request, response = app.test_client.get(
+        "/", params=[("test1", "1")]
+    )
+
+    assert request.args.pop("test1") == ["1"]
+    assert "test1" not in request.args
 
 @pytest.mark.asyncio
 async def test_query_string_asgi(app):


### PR DESCRIPTION
Per the issue in subject, should fix request.args.pop inconsistency.

When merged closes #2106 