### PR TITLE
Signal integration

### DIFF
--- a/sanic/server.py
+++ b/sanic/server.py
@@ -551,7 +551,7 @@ def serve(
             after_stop=after_stop,
         )
 
-    trigger_events(before_start, loop)
+    loop.run_until_complete(app._startup())
 
     try:
         http_server = loop.run_until_complete(server_coroutine)
@@ -559,7 +559,7 @@ def serve(
         logger.exception("Unable to start server")
         return
 
-    trigger_events(after_start, loop)
+    # dispatch_signal(app, loop, "server.worker.stop")
 
     # Ignore SIGINT when run_multiple
     if run_multiple:

--- a/sanic/touchup/__init__.py
+++ b/sanic/touchup/__init__.py
@@ -1,0 +1,8 @@
+from .meta import TouchUpMeta
+from .service import TouchUp
+
+
+__all__ = (
+    "TouchUp",
+    "TouchUpMeta",
+)

--- a/sanic/touchup/meta.py
+++ b/sanic/touchup/meta.py
@@ -1,0 +1,21 @@
+from sanic.exceptions import SanicException
+
+from .service import TouchUp
+
+
+class TouchUpMeta(type):
+    def __new__(cls, name, bases, attrs, **kwargs):
+        gen_class = super().__new__(cls, name, bases, attrs, **kwargs)
+
+        methods = attrs.get("__touchup__")
+        if methods:
+
+            for method in methods:
+                if method not in attrs:
+                    raise SanicException(
+                        "Cannot perform touchup on non-existent method: "
+                        f"{name}.{method}"
+                    )
+                TouchUp.register(gen_class, method)
+
+        return gen_class

--- a/sanic/touchup/schemes/__init__.py
+++ b/sanic/touchup/schemes/__init__.py
@@ -1,0 +1,5 @@
+from .base import BaseScheme
+from .ode import OptionalDispatchEvent  # noqa
+
+
+__all__ = ("BaseScheme",)

--- a/sanic/touchup/schemes/base.py
+++ b/sanic/touchup/schemes/base.py
@@ -1,0 +1,39 @@
+from abc import ABC, abstractmethod
+from typing import List, Set, Type
+
+
+class BaseScheme(ABC):
+    ident: str
+    _registry: Set[Type] = set()
+
+    def __init__(self, app) -> None:
+        self.app = app
+
+    @abstractmethod
+    def run(self, directive: str, offset: int) -> None:
+        ...
+
+    def __init_subclass__(cls):
+        BaseScheme._registry.add(cls)
+
+    @property
+    def trigger(self):
+        return f"# {self.ident}: "
+
+    def __call__(self, lines: List[str]) -> List[str]:
+        self.output: List[str] = []
+
+        for line in lines:
+            stripped = line.lstrip()
+            if stripped.startswith(self.trigger):
+                offset = len(line) - len(stripped)
+                line = line.replace("  # noqa", "")
+                _, directive = line.split(self.trigger, 1)
+                self.run(directive, offset)
+            else:
+                self.add_line(line)
+
+        return self.output
+
+    def add_line(self, line: str) -> None:
+        self.output.append(line)

--- a/sanic/touchup/schemes/ode.py
+++ b/sanic/touchup/schemes/ode.py
@@ -1,0 +1,22 @@
+from .base import BaseScheme
+
+
+class OptionalDispatchEvent(BaseScheme):
+    ident = "ODE"
+
+    def run(self, directive: str, offset: int) -> None:
+        events = [signal.path for signal in self.app.signal_router.routes]
+
+        if events:
+            try:
+                event, context = directive.split(" ", 1)
+                ctx = f", context={context}"
+            except ValueError:
+                event = directive
+                ctx = ""
+
+            if event in events:
+                pad = " " * offset
+                self.add_line(
+                    f'{pad}await self.dispatch("{event}"{ctx}, inline=True)'
+                )

--- a/sanic/touchup/service.py
+++ b/sanic/touchup/service.py
@@ -1,0 +1,35 @@
+from inspect import getmembers, getmodule, getsource
+from textwrap import dedent
+from typing import Any, Dict, Set, Tuple, Type
+
+from .schemes import BaseScheme
+
+
+class TouchUp:
+    _registry: Set[Tuple[Type, str]] = set()
+
+    @classmethod
+    def run(cls, app):
+        for target, method_name in cls._registry:
+            method = getattr(target, method_name)
+            module = getmodule(target)
+            module_globals = dict(getmembers(module))
+
+            raw_source = getsource(method)
+            src = dedent(raw_source)
+            lines = src.splitlines()
+
+            for scheme in BaseScheme._registry:
+                handler = scheme(app)
+                lines = handler(lines)
+
+            joined = "\n".join(lines)
+
+            compiled_src = compile(joined, "", "exec")
+            exec_locals: Dict[str, Any] = {}
+            exec(compiled_src, module_globals, exec_locals)
+            setattr(target, method_name, exec_locals[method_name])
+
+    @classmethod
+    def register(cls, target, method_name):
+        cls._registry.add((target, method_name))


### PR DESCRIPTION
This is the beginning of the second stage of #1630. More particularly, it introduces a new module to Sanic internals: `sanic.touchup`.

The idea with this module is that there will be predefined comment/markers that will modify executable functions at startup.

---

For example, the code to run request middleware looks like this:

```python
            for middleware in applicable_middleware:
                # ODE: http.middleware.before {"request": request}
                response = middleware(request)
                if isawaitable(response):
                    response = await response
                # ODE: http.middleware.after {"request": request, "response": response}  # noqa
                if response:
                    return response
```

At startup, there is a predefined interface that will lookup whether or not the `http.middleware.before` or `http.middleware.after` signals have been implemented. If not, then nothing happens. If yes, then the touchup module will inject signal dispatchers in those locations.

This should allow Sanic developers to make good use of signals to inject functionality, but not to slow down the req/resp cycle needlessly.

---

## TODO:

- Conditional block scheme
    ```python
    # CB: start some_expression
    do_something_only_if_startup_condition_exists()
    # CB: end
    ```     
- unit tests