### PR TITLE
support app factory patten in CLI

### DIFF
--- a/sanic/__main__.py
+++ b/sanic/__main__.py
@@ -76,6 +76,11 @@ def main():
         help="Watch source directory for file changes and reload on changes",
     )
     parser.add_argument(
+        "--factory",
+        action="store_true",
+        help="Treat app as an application factory, i.e. a () -> <Sanic app> callable.",
+    )
+    parser.add_argument(
         "-v",
         "--version",
         action="version",
@@ -99,6 +104,9 @@ def main():
 
         module = import_module(module_name)
         app = getattr(module, app_name, None)
+        if args.factory:
+            app = app()
+
         app_name = type(app).__name__
 
         if not isinstance(app, Sanic):

--- a/sanic/__main__.py
+++ b/sanic/__main__.py
@@ -105,16 +105,20 @@ def main():
         delimiter = ":" if ":" in args.module else "."
         module_name, app_name = args.module.rsplit(delimiter, 1)
 
+        if app_name.endswith("()"):
+            args.factory = True
+            app_name = app_name[:-2]
+
         module = import_module(module_name)
         app = getattr(module, app_name, None)
         if args.factory:
             app = app()
 
-        app_name = type(app).__name__
+        app_type_name = type(app).__name__
 
         if not isinstance(app, Sanic):
             raise ValueError(
-                f"Module is not a Sanic app, it is a {app_name}.  "
+                f"Module is not a Sanic app, it is a {app_type_name}.  "
                 f"Perhaps you meant {args.module}.app?"
             )
         if args.cert is not None or args.key is not None:

--- a/sanic/__main__.py
+++ b/sanic/__main__.py
@@ -78,7 +78,10 @@ def main():
     parser.add_argument(
         "--factory",
         action="store_true",
-        help="Treat app as an application factory, i.e. a () -> <Sanic app> callable.",
+        help=(
+            "Treat app as an application factory, "
+            "i.e. a () -> <Sanic app> callable."
+        ),
     )
     parser.add_argument(
         "-v",

--- a/sanic/utils.py
+++ b/sanic/utils.py
@@ -105,7 +105,7 @@ def load_module_from_file_location(
             _mod_spec = spec_from_file_location(
                 name, location, *args, **kwargs
             )
-            assert _mod_spec is not None # type assertion for mypy
+            assert _mod_spec is not None  # type assertion for mypy
             module = module_from_spec(_mod_spec)
             _mod_spec.loader.exec_module(module)  # type: ignore
 

--- a/sanic/utils.py
+++ b/sanic/utils.py
@@ -105,7 +105,7 @@ def load_module_from_file_location(
             _mod_spec = spec_from_file_location(
                 name, location, *args, **kwargs
             )
-            assert _mod_spec is not None
+            assert _mod_spec is not None # type assertion for mypy
             module = module_from_spec(_mod_spec)
             _mod_spec.loader.exec_module(module)  # type: ignore
 

--- a/sanic/utils.py
+++ b/sanic/utils.py
@@ -105,6 +105,7 @@ def load_module_from_file_location(
             _mod_spec = spec_from_file_location(
                 name, location, *args, **kwargs
             )
+            assert _mod_spec is not None
             module = module_from_spec(_mod_spec)
             _mod_spec.loader.exec_module(module)  # type: ignore
 

--- a/tests/fake/server.py
+++ b/tests/fake/server.py
@@ -30,3 +30,7 @@ async def app_info_dump(app: Sanic, _):
 @app.after_server_start
 async def shutdown(app: Sanic, _):
     app.stop()
+
+
+def create_app():
+    return app

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,7 +26,15 @@ def capture(command):
     return out, err, proc.returncode
 
 
-@pytest.mark.parametrize("appname", ("fake.server.app", "fake.server:app"))
+@pytest.mark.parametrize(
+    "appname",
+    (
+        "fake.server.app",
+        "fake.server:app",
+        "fake.server:create_app()",
+        "fake.server.create_app()",
+    )
+)
 def test_server_run(appname):
     command = ["sanic", appname]
     out, err, exitcode = capture(command)

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,8 @@ commands =
 
 [testenv:type-checking]
 deps =
-    mypy
+    mypy>=0.900
+    types-ujson
 
 commands =
     mypy sanic

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ commands =
 
 [testenv:type-checking]
 deps =
-    mypy>=0.900
+    mypy>=0.901
     types-ujson
 
 commands =


### PR DESCRIPTION
similar to `uvicorn --factory`

It might be nicer to support the [gunicorn](https://docs.gunicorn.org/en/stable/run.html#gunicorn) `()` syntax:

> The variable name can also be a function call. In that case the name will be imported from the module, then called to get the application object. This is commonly referred to as the “application factory” pattern.