### PR TITLE
Add reloading on addtional directories

### DIFF
--- a/sanic/__main__.py
+++ b/sanic/__main__.py
@@ -1,13 +1,7 @@
 import os
 import sys
 
-from argparse import (
-    ArgumentDefaultsHelpFormatter,
-    ArgumentParser,
-    MetavarTypeHelpFormatter,
-    RawDescriptionHelpFormatter,
-    RawTextHelpFormatter,
-)
+from argparse import ArgumentParser, RawTextHelpFormatter
 from importlib import import_module
 from typing import Any, Dict, Optional
 

--- a/sanic/__main__.py
+++ b/sanic/__main__.py
@@ -1,7 +1,13 @@
 import os
 import sys
 
-from argparse import ArgumentParser, RawDescriptionHelpFormatter
+from argparse import (
+    ArgumentDefaultsHelpFormatter,
+    ArgumentParser,
+    MetavarTypeHelpFormatter,
+    RawDescriptionHelpFormatter,
+    RawTextHelpFormatter,
+)
 from importlib import import_module
 from typing import Any, Dict, Optional
 
@@ -17,7 +23,7 @@ class SanicArgumentParser(ArgumentParser):
     def add_bool_arguments(self, *args, **kwargs):
         group = self.add_mutually_exclusive_group()
         group.add_argument(*args, action="store_true", **kwargs)
-        kwargs["help"] = "no " + kwargs["help"]
+        kwargs["help"] = f"no {kwargs['help']}\n "
         group.add_argument(
             "--no-" + args[0][2:], *args[1:], action="store_false", **kwargs
         )
@@ -27,7 +33,15 @@ def main():
     parser = SanicArgumentParser(
         prog="sanic",
         description=BASE_LOGO,
-        formatter_class=RawDescriptionHelpFormatter,
+        formatter_class=lambda prog: RawTextHelpFormatter(
+            prog, max_help_position=33
+        ),
+    )
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=f"Sanic {__version__}; Routing {__routing_version__}",
     )
     parser.add_argument(
         "-H",
@@ -51,13 +65,24 @@ def main():
         dest="unix",
         type=str,
         default="",
-        help="location of unix socket",
+        help="location of unix socket\n ",
     )
     parser.add_argument(
         "--cert", dest="cert", type=str, help="location of certificate for SSL"
     )
     parser.add_argument(
-        "--key", dest="key", type=str, help="location of keyfile for SSL."
+        "--key", dest="key", type=str, help="location of keyfile for SSL\n "
+    )
+    parser.add_bool_arguments(
+        "--access-logs", dest="access_log", help="display access logs"
+    )
+    parser.add_argument(
+        "--factory",
+        action="store_true",
+        help=(
+            "Treat app as an application factory, "
+            "i.e. a () -> <Sanic app> callable\n "
+        ),
     )
     parser.add_argument(
         "-w",
@@ -65,7 +90,7 @@ def main():
         dest="workers",
         type=int,
         default=1,
-        help="number of worker processes [default 1]",
+        help="number of worker processes [default 1]\n ",
     )
     parser.add_argument("-d", "--debug", dest="debug", action="store_true")
     parser.add_argument(
@@ -80,24 +105,7 @@ def main():
         "--include-dir",
         dest="include_dir",
         action="append",
-        help="Extra directories to watch and reload on changes",
-    )
-    parser.add_argument(
-        "--factory",
-        action="store_true",
-        help=(
-            "Treat app as an application factory, "
-            "i.e. a () -> <Sanic app> callable."
-        ),
-    )
-    parser.add_argument(
-        "-v",
-        "--version",
-        action="version",
-        version=f"Sanic {__version__}; Routing {__routing_version__}",
-    )
-    parser.add_bool_arguments(
-        "--access-logs", dest="access_log", help="display access logs"
+        help="Extra directories to watch and reload on changes\n ",
     )
     parser.add_argument(
         "module", help="path to your Sanic app. Example: path.to.server:app"

--- a/sanic/__main__.py
+++ b/sanic/__main__.py
@@ -153,7 +153,7 @@ def main():
 
         if args.path:
             if args.auto_reload or args.debug:
-                kwargs["path"] = args.path
+                kwargs["reload_dir"] = args.path
             else:
                 error_logger.warning(
                     "Ignoring '--reload-dir' since auto reloading was not "

--- a/sanic/__main__.py
+++ b/sanic/__main__.py
@@ -96,9 +96,9 @@ def main():
         help="Watch source directory for file changes and reload on changes",
     )
     parser.add_argument(
-        "-D",
+        "-R",
         "--reload-dir",
-        dest="reload_dir",
+        dest="path",
         action="append",
         help="Extra directories to watch and reload on changes\n ",
     )
@@ -151,9 +151,9 @@ def main():
         if args.auto_reload:
             kwargs["auto_reload"] = True
 
-        if args.reload_dir:
+        if args.path:
             if args.auto_reload or args.debug:
-                kwargs["reload_dir"] = args.reload_dir
+                kwargs["path"] = args.path
             else:
                 error_logger.warning(
                     "Ignoring '--reload-dir' since auto reloading was not "

--- a/sanic/__main__.py
+++ b/sanic/__main__.py
@@ -76,6 +76,13 @@ def main():
         help="Watch source directory for file changes and reload on changes",
     )
     parser.add_argument(
+        "-D",
+        "--include-dir",
+        dest="include_dir",
+        action="append",
+        help="Extra directories to watch and reload on changes",
+    )
+    parser.add_argument(
         "--factory",
         action="store_true",
         help=(
@@ -140,6 +147,17 @@ def main():
         }
         if args.auto_reload:
             kwargs["auto_reload"] = True
+
+        if args.include_dir:
+            if args.auto_reload or args.debug:
+                kwargs["include_dir"] = args.include_dir
+            else:
+                error_logger.warning(
+                    "Ignoring '--include-dir' since auto reloading was not "
+                    "enabled. If you would like to watch directories for "
+                    "changes, consider using --debug or --auto-reload."
+                )
+
         app.run(**kwargs)
     except ImportError as e:
         if module_name.startswith(e.name):

--- a/sanic/__main__.py
+++ b/sanic/__main__.py
@@ -89,6 +89,7 @@ def main():
     parser.add_argument("-d", "--debug", dest="debug", action="store_true")
     parser.add_argument(
         "-r",
+        "--reload",
         "--auto-reload",
         dest="auto_reload",
         action="store_true",
@@ -96,8 +97,8 @@ def main():
     )
     parser.add_argument(
         "-D",
-        "--include-dir",
-        dest="include_dir",
+        "--reload-dir",
+        dest="reload_dir",
         action="append",
         help="Extra directories to watch and reload on changes\n ",
     )
@@ -150,12 +151,12 @@ def main():
         if args.auto_reload:
             kwargs["auto_reload"] = True
 
-        if args.include_dir:
+        if args.reload_dir:
             if args.auto_reload or args.debug:
-                kwargs["include_dir"] = args.include_dir
+                kwargs["reload_dir"] = args.reload_dir
             else:
                 error_logger.warning(
-                    "Ignoring '--include-dir' since auto reloading was not "
+                    "Ignoring '--reload-dir' since auto reloading was not "
                     "enabled. If you would like to watch directories for "
                     "changes, consider using --debug or --auto-reload."
                 )

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -392,7 +392,7 @@ class Sanic(BaseSanic):
             if self.config.EVENT_AUTOREGISTER:
                 self.signal_router.reset()
                 self.add_signal(None, event)
-                signal = self.signal_router.name_index.get(event)
+                signal = self.signal_router.name_index[event]
                 self.signal_router.finalize()
             else:
                 raise NotFound("Could not find signal %s" % event)
@@ -849,7 +849,7 @@ class Sanic(BaseSanic):
         access_log: Optional[bool] = None,
         unix: Optional[str] = None,
         loop: None = None,
-        include_dir: Optional[Union[List[str], str]] = None,
+        reload_dir: Optional[Union[List[str], str]] = None,
     ) -> None:
         """
         Run the HTTP Server and listen until keyboard interrupt or term
@@ -884,11 +884,11 @@ class Sanic(BaseSanic):
         :type unix: str
         :return: Nothing
         """
-        if include_dir:
-            if isinstance(include_dir, str):
-                include_dir = [include_dir]
+        if reload_dir:
+            if isinstance(reload_dir, str):
+                reload_dir = [reload_dir]
 
-            for directory in include_dir:
+            for directory in reload_dir:
                 direc = Path(directory)
                 if not direc.is_dir():
                     logger.warning(

--- a/sanic/reloader_helpers.py
+++ b/sanic/reloader_helpers.py
@@ -36,11 +36,6 @@ def _iter_module_files():
                 yield filename
 
 
-def _iter_dirs(dirs):
-    for filename in (d.glob("**/*") for d in dirs):
-        yield filename
-
-
 def _get_args_for_reloading():
     """Returns the executable."""
     main_module = sys.modules["__main__"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,7 +33,7 @@ def capture(command):
         "fake.server:app",
         "fake.server:create_app()",
         "fake.server.create_app()",
-    )
+    ),
 )
 def test_server_run(appname):
     command = ["sanic", appname]

--- a/tests/test_reloader.py
+++ b/tests/test_reloader.py
@@ -158,12 +158,12 @@ async def test_reloader_live_with_dir(runargs, mode):
     with TemporaryDirectory() as tmpdir:
         filename = os.path.join(tmpdir, "reloader.py")
         config_file = os.path.join(tmpdir, "config.json")
-        runargs["include_dir"] = tmpdir
+        runargs["reload_dir"] = tmpdir
         write_json_config_app(filename, config_file, **runargs)
         text = write_file(config_file)
         command = argv[mode]
         if mode == "sanic":
-            command += ["--include-dir", tmpdir]
+            command += ["--reload-dir", tmpdir]
         proc = Popen(command, cwd=tmpdir, stdout=PIPE, creationflags=flags)
         try:
             timeout = Timer(TIMER_DELAY, terminate, [proc])


### PR DESCRIPTION
Resolves #2143 

This allows the auto-reloader to watch additional directories beyond just the Python modules for changes. Implemented in two ways:

**Via app.run**
```python
app.run(..., reload_dir="./some/path")
# or
app.run(..., reload_dir=["./some/path", "./some/other/path"])
```

**Via cli**
```
sanic --reload-dir=./some/path
sanic -D ./some/path -D ./some/other/path
```