### PR TITLE
CBV alternate attach; CompositionView deprecate

### DIFF
--- a/sanic/views.py
+++ b/sanic/views.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Iterable,
+    List,
+    Optional,
+    Union,
+)
 from warnings import warn
 
 from sanic.constants import HTTP_METHODS
@@ -52,11 +60,26 @@ class HTTPMethodView:
         cls,
         attach: Optional[Union[Sanic, Blueprint]] = None,
         uri: str = "",
-        *args,
-        **kwargs,
+        methods: Iterable[str] = frozenset({"GET"}),
+        host: Optional[str] = None,
+        strict_slashes: Optional[bool] = None,
+        version: Optional[int] = None,
+        name: Optional[str] = None,
+        stream: bool = False,
+        version_prefix: str = "/v",
     ) -> None:
         if attach:
-            cls.attach(attach, uri, *args, **kwargs)
+            cls.attach(
+                attach,
+                uri=uri,
+                methods=methods,
+                host=host,
+                strict_slashes=strict_slashes,
+                version=version,
+                name=name,
+                stream=stream,
+                version_prefix=version_prefix,
+            )
 
     def dispatch_request(self, request, *args, **kwargs):
         handler = getattr(self, request.method.lower(), None)
@@ -85,9 +108,28 @@ class HTTPMethodView:
 
     @classmethod
     def attach(
-        cls, to: Union[Sanic, Blueprint], uri: str, *args, **kwargs
+        cls,
+        to: Union[Sanic, Blueprint],
+        uri: str,
+        methods: Iterable[str] = frozenset({"GET"}),
+        host: Optional[str] = None,
+        strict_slashes: Optional[bool] = None,
+        version: Optional[int] = None,
+        name: Optional[str] = None,
+        stream: bool = False,
+        version_prefix: str = "/v",
     ) -> None:
-        to.add_route(cls.as_view(), uri, *args, **kwargs)
+        to.add_route(
+            cls.as_view(),
+            uri=uri,
+            methods=methods,
+            host=host,
+            strict_slashes=strict_slashes,
+            version=version,
+            name=name,
+            stream=stream,
+            version_prefix=version_prefix,
+        )
 
 
 def stream(func):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -77,6 +77,56 @@ def test_with_bp(app):
     assert response.text == "I am get method"
 
 
+def test_with_attach(app):
+    class DummyView(HTTPMethodView):
+        def get(self, request):
+            return text("I am get method")
+
+    DummyView.attach(app, "/")
+
+    request, response = app.test_client.get("/")
+
+    assert response.text == "I am get method"
+
+
+def test_with_sub_init(app):
+    class DummyView(HTTPMethodView, attach=app, uri="/"):
+        def get(self, request):
+            return text("I am get method")
+
+    request, response = app.test_client.get("/")
+
+    assert response.text == "I am get method"
+
+
+def test_with_attach_and_bp(app):
+    bp = Blueprint("test_text")
+
+    class DummyView(HTTPMethodView):
+        def get(self, request):
+            return text("I am get method")
+
+    DummyView.attach(bp, "/")
+
+    app.blueprint(bp)
+    request, response = app.test_client.get("/")
+
+    assert response.text == "I am get method"
+
+
+def test_with_sub_init_and_bp(app):
+    bp = Blueprint("test_text")
+
+    class DummyView(HTTPMethodView, attach=bp, uri="/"):
+        def get(self, request):
+            return text("I am get method")
+
+    app.blueprint(bp)
+    request, response = app.test_client.get("/")
+
+    assert response.text == "I am get method"
+
+
 def test_with_bp_with_url_prefix(app):
     bp = Blueprint("test_text", url_prefix="/test1")
 
@@ -218,15 +268,15 @@ def test_composition_view_runs_methods_as_expected(app, method):
         assert response.status == 200
         assert response.text == "first method"
 
-        # response = view(request)
-        # assert response.body.decode() == "first method"
+        response = view(request)
+        assert response.body.decode() == "first method"
 
-    # if method in ["DELETE", "PATCH"]:
-    #     request, response = getattr(app.test_client, method.lower())("/")
-    #     assert response.text == "second method"
+    if method in ["DELETE", "PATCH"]:
+        request, response = getattr(app.test_client, method.lower())("/")
+        assert response.text == "second method"
 
-    #     response = view(request)
-    #     assert response.body.decode() == "second method"
+        response = view(request)
+        assert response.body.decode() == "second method"
 
 
 @pytest.mark.parametrize("method", HTTP_METHODS)
@@ -244,3 +294,12 @@ def test_composition_view_rejects_invalid_methods(app, method):
     if method in ["DELETE", "PATCH"]:
         request, response = getattr(app.test_client, method.lower())("/")
         assert response.status == 405
+
+
+def test_composition_view_deprecation():
+    message = (
+        "CompositionView has been deprecated and will be removed in v21.12. "
+        "Please update your view to HTTPMethodView."
+    )
+    with pytest.warns(DeprecationWarning, match=message):
+        CompositionView()


### PR DESCRIPTION
Resolves #2069 

`CompositionView` is deprecated and will be removed in 21.12

Adds two new methods for attaching CBVs.

```python
class DummyView(HTTPMethodView):
    def get(self, request):
        return text("I am get method")

DummyView.attach(Sanic.get_app(), "/")
```

and

```python
class DummyView(HTTPMethodView, attach=app, uri="/"):
    def get(self, request):
        return text("I am get method")
```
