### PR TITLE
Avoid dangling sockets by using abort() instead of close()

### DIFF
--- a/sanic/server.py
+++ b/sanic/server.py
@@ -286,7 +286,7 @@ class HttpProtocol(asyncio.Protocol):
         """
         # Cause a call to connection_lost where further cleanup occurs
         if self.transport:
-            self.transport.close()
+            self.transport.abort()
             self.transport = None
 
     # -------------------------------------------- #


### PR DESCRIPTION
Fixes #2190 