### PR TITLE
Change dumps to AnyStr

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -738,11 +738,12 @@ class Sanic(BaseSanic):
             request.route = route
 
             if (
-                request.stream.request_body  # type: ignore
+                request.stream
+                and request.stream.request_body
                 and not route.ctx.ignore_body
             ):
 
-                if hasattr(handler, "is_stream") and request.stream:
+                if hasattr(handler, "is_stream"):
                     # Streaming handler: lift the size limit
                     request.stream.request_max_size = float("inf")
                 else:

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -193,7 +193,7 @@ class Sanic(BaseSanic):
         self.router.ctx.app = self
 
         if dumps:
-            BaseHTTPResponse._dumps = dumps
+            BaseHTTPResponse._dumps = dumps  # type: ignore
 
     @property
     def loop(self):

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -742,9 +742,9 @@ class Sanic(BaseSanic):
                 and not route.ctx.ignore_body
             ):
 
-                if hasattr(handler, "is_stream"):
+                if hasattr(handler, "is_stream") and request.stream:
                     # Streaming handler: lift the size limit
-                    request.stream.request_max_size = float("inf")  # type: ignore
+                    request.stream.request_max_size = float("inf")
                 else:
                     # Non-streaming handler: preload body
                     await request.receive_body()

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -21,6 +21,7 @@ from traceback import format_exc
 from types import SimpleNamespace
 from typing import (
     Any,
+    AnyStr,
     Awaitable,
     Callable,
     Coroutine,
@@ -137,7 +138,7 @@ class Sanic(BaseSanic):
         log_config: Optional[Dict[str, Any]] = None,
         configure_logging: bool = True,
         register: Optional[bool] = None,
-        dumps: Optional[Callable[..., str]] = None,
+        dumps: Optional[Callable[..., AnyStr]] = None,
     ) -> None:
         super().__init__(name=name)
 
@@ -736,9 +737,7 @@ class Sanic(BaseSanic):
 
                 if hasattr(handler, "is_stream"):
                     # Streaming handler: lift the size limit
-                    request.stream.request_max_size = float(  # type: ignore
-                        "inf"
-                    )
+                    request.stream.request_max_size = float("inf")  # type: ignore
                 else:
                     # Non-streaming handler: preload body
                     await request.receive_body()

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ ujson = "ujson>=1.35" + env_dependency
 uvloop = "uvloop>=0.5.3" + env_dependency
 types_ujson = "types-ujson" + env_dependency
 requirements = [
-    "sanic-routing==0.7.0",
+    "sanic-routing~=0.7",
     "httptools>=0.0.10",
     uvloop,
     ujson,


### PR DESCRIPTION
A dumps method that returns a bytes string (like orjson.dumps) is valid. So, the type annotation needs to be `AnyStr`.