### PR TITLE
unexpected error handling on static requests

### DIFF
--- a/sanic/mixins/routes.py
+++ b/sanic/mixins/routes.py
@@ -781,6 +781,7 @@ class RouteMixin:
  path={file_or_directory}, "
                 f"relative_url={__file_uri__}"
             )
+            raise
 
     def _register_static(
         self,

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -461,6 +461,22 @@ def test_nested_dir(app, static_file_directory):
     assert response.text == "foo\n"
 
 
+def test_handle_is_a_directory_error(app, static_file_directory):
+    error_text = "Is a directory. Access denied"
+    app.static("/static", static_file_directory)
+
+    @app.exception(Exception)
+    async def handleStaticDirError(request, exception):
+        if isinstance(exception, IsADirectoryError):
+            return text(error_text, status=403)
+        raise exception
+
+    request, response = app.test_client.get("/static/")
+
+    assert response.status == 403
+    assert response.text == error_text
+
+
 def test_stack_trace_on_not_found(app, static_file_directory, caplog):
     app.static("/static", static_file_directory)
 


### PR DESCRIPTION
It was impossible to handle any exceptions from `_static_request_handler` without magic