### PR TITLE
Call abort() on sockets after close() to prevent dangling sockets

### DIFF
--- a/sanic/server/runners.py
+++ b/sanic/server/runners.py
@@ -180,7 +180,7 @@ def serve(
             if hasattr(conn, "websocket") and conn.websocket:
                 coros.append(conn.websocket.close_connection())
             else:
-                conn.close()
+                conn.abort()
 
         _shutdown = asyncio.gather(*coros)
         loop.run_until_complete(_shutdown)


### PR DESCRIPTION
Fixes #2190
Replaces #2191 

This adds some help helper functionality to the base SanicProtocol
Added `SanicProtocol.abort()` method to force-close a connection to prevent dangling sockets.
Added optional timeout arg to `SanicProtocol.close()` which waits a given amount of time after calling `close()` to call `abort()` if the connection is still open.
Defaults to the same timeout period as `GRACEFUL_SHUTDOWN_TIMEOUT` (for convenience).

Also change one usage of `.close()` to `.abort()` outright, on server shutdown when `GRACEFUL_SHUTDOWN_TIMEOUT` has already passed.