### PR TITLE
Add new CLI options

### DIFF
--- a/sanic/__main__.py
+++ b/sanic/__main__.py
@@ -226,9 +226,7 @@ def main():
             try:
                 args.workers = len(os.sched_getaffinity(0))
             except AttributeError:
-                error_logger.warning(
-                    "Ignoring '--fast' since it is not supported on this OS."
-                )
+                args.workers = os.cpu_count()
 
         kwargs = {
             "host": args.host,

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -1014,6 +1014,14 @@ class Sanic(BaseSanic, metaclass=TouchUpMeta):
             )
 
         if auto_reload or auto_reload is None and debug:
+            if auto_reload is None and debug:
+                error_logger.warning(
+                    DeprecationWarning(
+                        "Enabling auto-reload via debug mode is deprecated "
+                        "and will be removed in v22.3. Consider using "
+                        "'sanic server:app --dev' instead."
+                    )
+                )
             self.auto_reload = True
             if os.environ.get("SANIC_SERVER_RUNNING") != "true":
                 return reloader_helpers.watchdog(1.0, self)
@@ -1028,6 +1036,15 @@ class Sanic(BaseSanic, metaclass=TouchUpMeta):
         # if access_log is passed explicitly change config.ACCESS_LOG
         if access_log is not None:
             self.config.ACCESS_LOG = access_log
+        else:
+            error_logger.warning(
+                DeprecationWarning(
+                    "Enabling access logging by default is deprecated "
+                    "and will be removed in v22.3. Consider using "
+                    "'sanic server:app --access-logs' explicitly, or "
+                    "'sanic server:app --dev' instead."
+                )
+            )
 
         server_settings = self._helper(
             host=host,


### PR DESCRIPTION
Implements and closes #2169 

[As mentioned here](https://github.com/sanic-org/sanic/issues/2169#issuecomment-917472800), this adds some new flags the the CLI:

- `--mode` Can be either `debug` or `prod`
- PROD mode is new, it bumps logging up to `WARNING`
- DEBUG mode will deprecate auto-reload
- `--dev` is a shortcut to DEBUG mode + auto-reload
- `--fast` is a shortcut to max out the available workers

