### PR TITLE
Change dev install command

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -19,7 +19,7 @@ a virtual environment already set up, then run:
 
 .. code-block:: bash
 
-   pip3 install -e . ".[dev]"
+   pip install -e ".[dev]"
 
 Dependency Changes
 ------------------


### PR DESCRIPTION
If `.` is included, pip complains about a conflict between `sanic` and `sanic[dev]`. Additionally, dropped the `3` because venvs and most installs already have `pip` refer to Python 3.