### PR TITLE
More consistent config setting with post-FALLBACK_ERROR_FORMAT apply

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -190,14 +190,12 @@ class Sanic(BaseSanic, metaclass=TouchUpMeta):
         self._state: ApplicationState = ApplicationState(app=self)
         self.blueprints: Dict[str, Blueprint] = {}
         self.config: Config = config or Config(
-            load_env=load_env, env_prefix=env_prefix
+            load_env=load_env, env_prefix=env_prefix, app=self,
         )
         self.configure_logging: bool = configure_logging
         self.ctx: Any = ctx or SimpleNamespace()
         self.debug = False
-        self.error_handler: ErrorHandler = error_handler or ErrorHandler(
-            fallback=self.config.FALLBACK_ERROR_FORMAT,
-        )
+        self.error_handler: ErrorHandler = error_handler or ErrorHandler()
         self.listeners: Dict[str, List[ListenerType[Any]]] = defaultdict(list)
         self.named_request_middleware: Dict[str, Deque[MiddlewareType]] = {}
         self.named_response_middleware: Dict[str, Deque[MiddlewareType]] = {}

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -190,7 +190,9 @@ class Sanic(BaseSanic, metaclass=TouchUpMeta):
         self._state: ApplicationState = ApplicationState(app=self)
         self.blueprints: Dict[str, Blueprint] = {}
         self.config: Config = config or Config(
-            load_env=load_env, env_prefix=env_prefix, app=self,
+            load_env=load_env,
+            env_prefix=env_prefix,
+            app=self,
         )
         self.configure_logging: bool = configure_logging
         self.ctx: Any = ctx or SimpleNamespace()

--- a/sanic/config.py
+++ b/sanic/config.py
@@ -141,9 +141,9 @@ class Config(dict):
                 if self.app and value != self.app.error_handler.fallback:
                     if self.app.error_handler.fallback != "auto":
                         warn(
-                            "Overriding non-default ErrorHandler fallback value. "
-                            f"Changing from {self.app.error_handler.fallback} "
-                            f"to {value}."
+                            "Overriding non-default ErrorHandler fallback "
+                            "value. Changing from "
+                            f"{self.app.error_handler.fallback} to {value}."
                         )
                     self.app.error_handler.fallback = value
             elif attr == "LOGO":

--- a/sanic/config.py
+++ b/sanic/config.py
@@ -47,7 +47,6 @@ DEFAULT_CONFIG = {
 
 
 class Config(dict):
-    app: Optional[Sanic]
     ACCESS_LOG: bool
     AUTO_RELOAD: bool
     EVENT_AUTOREGISTER: bool
@@ -86,7 +85,7 @@ class Config(dict):
         defaults = defaults or {}
         super().__init__({**DEFAULT_CONFIG, **defaults})
 
-        self.app = app
+        self._app = app
         self._LOGO = ""
 
         if keep_alive is not None:
@@ -109,7 +108,7 @@ class Config(dict):
 
         self._configure_header_size()
         self._check_error_format()
-        self.init = True
+        self._init = True
 
     def __getattr__(self, attr):
         try:
@@ -130,7 +129,7 @@ class Config(dict):
             self._post_set(attr, value)
 
     def _post_set(self, attr, value) -> None:
-        if self.get("init"):
+        if self.get("_init"):
             if attr in (
                 "REQUEST_MAX_HEADER_SIZE",
                 "REQUEST_BUFFER_SIZE",
@@ -154,6 +153,10 @@ class Config(dict):
                     "be supported starting in v22.6.",
                     DeprecationWarning,
                 )
+
+    @property
+    def app(self):
+        return self._app
 
     @property
     def LOGO(self):

--- a/sanic/config.py
+++ b/sanic/config.py
@@ -1,12 +1,18 @@
+from __future__ import annotations
+
 from inspect import isclass
 from os import environ
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 from warnings import warn
 
 from sanic.errorpages import check_error_format
 from sanic.http import Http
 from sanic.utils import load_module_from_file_location, str_to_bool
+
+
+if TYPE_CHECKING:  # no cov
+    from sanic import Sanic
 
 
 SANIC_PREFIX = "SANIC_"
@@ -41,6 +47,7 @@ DEFAULT_CONFIG = {
 
 
 class Config(dict):
+    app: Optional[Sanic]
     ACCESS_LOG: bool
     AUTO_RELOAD: bool
     EVENT_AUTOREGISTER: bool
@@ -73,10 +80,13 @@ class Config(dict):
         load_env: Optional[Union[bool, str]] = True,
         env_prefix: Optional[str] = SANIC_PREFIX,
         keep_alive: Optional[bool] = None,
+        *,
+        app: Optional[Sanic] = None,
     ):
         defaults = defaults or {}
         super().__init__({**DEFAULT_CONFIG, **defaults})
 
+        self.app = app
         self._LOGO = ""
 
         if keep_alive is not None:
@@ -99,6 +109,7 @@ class Config(dict):
 
         self._configure_header_size()
         self._check_error_format()
+        self.init = True
 
     def __getattr__(self, attr):
         try:
@@ -106,23 +117,43 @@ class Config(dict):
         except KeyError as ke:
             raise AttributeError(f"Config has no '{ke.args[0]}'")
 
-    def __setattr__(self, attr, value):
-        self[attr] = value
-        if attr in (
-            "REQUEST_MAX_HEADER_SIZE",
-            "REQUEST_BUFFER_SIZE",
-            "REQUEST_MAX_SIZE",
-        ):
-            self._configure_header_size()
-        elif attr == "FALLBACK_ERROR_FORMAT":
-            self._check_error_format()
-        elif attr == "LOGO":
-            self._LOGO = value
-            warn(
-                "Setting the config.LOGO is deprecated and will no longer "
-                "be supported starting in v22.6.",
-                DeprecationWarning,
-            )
+    def __setattr__(self, attr, value) -> None:
+        self.update({attr: value})
+
+    def __setitem__(self, attr, value) -> None:
+        self.update({attr: value})
+
+    def update(self, *other, **kwargs) -> None:
+        other_mapping = {k: v for item in other for k, v in dict(item).items()}
+        super().update(*other, **kwargs)
+        for attr, value in {**other_mapping, **kwargs}.items():
+            self._post_set(attr, value)
+
+    def _post_set(self, attr, value) -> None:
+        if self.get("init"):
+            if attr in (
+                "REQUEST_MAX_HEADER_SIZE",
+                "REQUEST_BUFFER_SIZE",
+                "REQUEST_MAX_SIZE",
+            ):
+                self._configure_header_size()
+            elif attr == "FALLBACK_ERROR_FORMAT":
+                self._check_error_format()
+                if self.app and value != self.app.error_handler.fallback:
+                    if self.app.error_handler.fallback != "auto":
+                        warn(
+                            "Overriding non-default ErrorHandler fallback value. "
+                            f"Changing from {self.app.error_handler.fallback} "
+                            f"to {value}."
+                        )
+                    self.app.error_handler.fallback = value
+            elif attr == "LOGO":
+                self._LOGO = value
+                warn(
+                    "Setting the config.LOGO is deprecated and will no longer "
+                    "be supported starting in v22.6.",
+                    DeprecationWarning,
+                )
 
     @property
     def LOGO(self):

--- a/sanic/errorpages.py
+++ b/sanic/errorpages.py
@@ -394,7 +394,6 @@ def exception_response(
             # from the route
             if request.route:
                 try:
-                    print(f"{request.route.ctx.error_format=}")
                     if request.route.ctx.error_format:
                         render_format = request.route.ctx.error_format
                 except AttributeError:

--- a/sanic/errorpages.py
+++ b/sanic/errorpages.py
@@ -383,6 +383,7 @@ def exception_response(
     """
     content_type = None
 
+    print("exception_response", fallback)
     if not renderer:
         # Make sure we have something set
         renderer = base
@@ -393,7 +394,9 @@ def exception_response(
             # from the route
             if request.route:
                 try:
-                    render_format = request.route.ctx.error_format
+                    print(f"{request.route.ctx.error_format=}")
+                    if request.route.ctx.error_format:
+                        render_format = request.route.ctx.error_format
                 except AttributeError:
                     ...
 

--- a/sanic/mixins/routes.py
+++ b/sanic/mixins/routes.py
@@ -918,7 +918,7 @@ class RouteMixin:
 
         return route
 
-    def _determine_error_format(self, handler) -> str:
+    def _determine_error_format(self, handler) -> Optional[str]:
         if not isinstance(handler, CompositionView):
             try:
                 src = dedent(getsource(handler))
@@ -930,7 +930,7 @@ class RouteMixin:
             except (OSError, TypeError):
                 ...
 
-        return "auto"
+        return None
 
     def _get_response_types(self, node):
         types = set()

--- a/sanic/router.py
+++ b/sanic/router.py
@@ -139,11 +139,10 @@ class Router(BaseRouter):
             route.ctx.stream = stream
             route.ctx.hosts = hosts
             route.ctx.static = static
-            route.ctx.error_format = (
-                error_format or self.ctx.app.config.FALLBACK_ERROR_FORMAT
-            )
+            route.ctx.error_format = error_format
 
-            check_error_format(route.ctx.error_format)
+            if error_format:
+                check_error_format(route.ctx.error_format)
 
             routes.append(route)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,9 +1,9 @@
 from contextlib import contextmanager
-from email import message
 from os import environ
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from textwrap import dedent
+from unittest.mock import Mock
 
 import pytest
 
@@ -360,3 +360,31 @@ def test_deprecation_notice_when_setting_logo(app):
     )
     with pytest.warns(DeprecationWarning, match=message):
         app.config.LOGO = "My Custom Logo"
+
+
+def test_config_set_methods(app, monkeypatch):
+    post_set = Mock()
+    monkeypatch.setattr(Config, "_post_set", post_set)
+
+    app.config.FOO = 1
+    post_set.assert_called_once_with("FOO", 1)
+    post_set.reset_mock()
+
+    app.config["FOO"] = 2
+    post_set.assert_called_once_with("FOO", 2)
+    post_set.reset_mock()
+
+    app.config.update({"FOO": 3})
+    post_set.assert_called_once_with("FOO", 3)
+    post_set.reset_mock()
+
+    app.config.update([("FOO", 4)])
+    post_set.assert_called_once_with("FOO", 4)
+    post_set.reset_mock()
+
+    app.config.update(FOO=5)
+    post_set.assert_called_once_with("FOO", 5)
+    post_set.reset_mock()
+
+    app.config.update_config({"FOO": 6})
+    post_set.assert_called_once_with("FOO", 6)


### PR DESCRIPTION
**INTENDED FOR v21.9.2 RELEASE**

## Background re: `Config`

The `Config` object in Sanic is a heavily modified `dict`. There already were instances where we wanted to do some checks _post_ modification of a config value. **HOWEVER**, we were not consistently applying this post-apply.

It would trigger here:

```python
app.config.FOO = 123
```

But not here:

```python
app.config["FOO"] = 123
```

Or here:

```python
app.config.update({"FOO": 123})
```

## Issue re: `FALLBACK_ERROR_FORMAT`

The `ErrorHandler` took a value for fallback _at the time `Sanic()` was initialized_. This meant that applying a value after initializing your app would not always work as might be expected. In fact, this value was almost _always_ being ignored.

Furthermore, routes were taking the `app.config.FALLBACK_ERROR_FORMAT` when they were being applied. This is the reason that setting it in the global scope was working.

## What this PR does

This PR is meant to handle #2276. While investigating this issue, I uncovered the inconsistency with the `Config` setter, so the scope of the PR grew. But, I think this is enough of a "gotcha" that it too should be included in an update to the current Sanic release.

Here are all of the changes

### Change `Config` setters

All of the methods for setting values on the `Config` option are now consistent. No matter which method used, we will apply the post-set logic.

```python
app.config.FOO = 1
app.config["FOO"] = 2
app.config.update({"FOO": 3})
app.config.update([("FOO", 4)])
app.config.update(FOO=5)
app.config.update_config({"FOO": 6})  # everything supported here ultimately uses `config.update(...)`
```

### Add a new post-set to apply `FALLBACK_ERROR_FORMAT` to the error handler

Previously, we were already checking the value of `FALLBACK_ERROR_FORMAT` to make sure that it would be valid. Now, when you set this value in any scope it will also reach into the `error_handler` attached to the application instance and update its `fallback` value. 

There is a little bit of a break here though. To accomplish this, we needed to bring the `app` instance into the `Config` object. Ultimately, I think this makes sense and for most users out there they will never notice a difference. However, if you are using a custom `Config` object, you will not have the `app` set. Therefore, this post-apply `FALLBACK_ERROR_FORMAT` will not work. We will have to provide a notice about this.

### Default `route.ctx.error_handler` to `None` if it is not explicitly set

We will not longer _always_ add an `error_handler` to the route. Instead we will do it only when there is an explicit value from the route definition. This way any values or changes to the `config` or the `error_handler` will still be impactful at render-time.

Closes #2276