### PR TITLE
Nicer error handling after eof, warning for second response being created

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -61,6 +61,7 @@ from sanic.compat import OS_IS_WINDOWS, enable_windows_color_support
 from sanic.config import SANIC_PREFIX, Config
 from sanic.exceptions import (
     InvalidUsage,
+    ResponseException,
     SanicException,
     ServerError,
     ShouldNotHandleException,
@@ -739,8 +740,16 @@ class Sanic(BaseSanic, metaclass=TouchUpMeta):
         if isinstance(exception, ShouldNotHandleException):
             error_logger.exception(exception)
             return
-
-        request.reset_response()
+        try:
+            request.reset_response()
+        except ResponseException as _:
+            error_logger.exception(exception)
+            logger.error(
+                "Server error page was not sent to the client for the "
+                "exception above because a previous response has been "
+                "sent at least partially."
+            )
+            return
 
         # -------------------------------------------- #
         # Request Middleware

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -742,8 +742,8 @@ class Sanic(BaseSanic, metaclass=TouchUpMeta):
         ):
             error_logger.exception(exception)
             logger.error(
-                f"The error response won't be sent to the client for the "
-                "{exception} because a previous response has "
+                "The error response won't be sent to the client for the "
+                f"{exception} because a previous response has "
                 "already been sent at least partially."
             )
             return

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -1289,10 +1289,6 @@ class Sanic(BaseSanic, metaclass=TouchUpMeta):
     async def _run_response_middleware(
         self, request, response, request_name=None
     ):  # no cov
-        if response.middlewares_executed:
-            return response
-        else:
-            response.middlewares_executed = True
         named_middleware = self.named_response_middleware.get(
             request_name, deque()
         )

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -63,6 +63,7 @@ from sanic.exceptions import (
     InvalidUsage,
     SanicException,
     ServerError,
+    ShouldNotHandleException,
     URLBuildError,
 )
 from sanic.handlers import ErrorHandler
@@ -734,6 +735,12 @@ class Sanic(BaseSanic, metaclass=TouchUpMeta):
             inline=True,
             context={"request": request, "exception": exception},
         )
+
+        if isinstance(exception, ShouldNotHandleException):
+            error_logger.exception(exception)
+            return
+
+        request.reset_response()
 
         # -------------------------------------------- #
         # Request Middleware

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -742,8 +742,8 @@ class Sanic(BaseSanic, metaclass=TouchUpMeta):
         ):
             error_logger.exception(exception)
             logger.error(
-                "The error response won't be sent to the client for the exception: "
-                f'"{exception}" because a previous response has '
+                "The error response won't be sent to the client for the "
+                f'exception: "{exception}" because a previous response has '
                 "already been sent at least partially."
             )
             return

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -743,7 +743,7 @@ class Sanic(BaseSanic, metaclass=TouchUpMeta):
             error_logger.exception(exception)
             logger.error(
                 "The error response won't be sent to the client for the exception: "
-                f"\"{exception}\" because a previous response has "
+                f'"{exception}" because a previous response has '
                 "already been sent at least partially."
             )
             return

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -1287,10 +1287,7 @@ class Sanic(BaseSanic, metaclass=TouchUpMeta):
         return None
 
     async def _run_response_middleware(
-        self,
-        request: Request,
-        response: BaseHTTPResponse,
-        request_name: Optional[str] = None,
+        self, request, response, request_name=None
     ):  # no cov
         if response.middlewares_executed:
             return response

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -742,8 +742,8 @@ class Sanic(BaseSanic, metaclass=TouchUpMeta):
         ):
             error_logger.exception(exception)
             logger.error(
-                "The error page was not sent to the client for the "
-                "exception raised above because a previous response has "
+                f"The error response won't be sent to the client for the "
+                "{exception} because a previous response has "
                 "already been sent at least partially."
             )
             return

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -742,8 +742,8 @@ class Sanic(BaseSanic, metaclass=TouchUpMeta):
         ):
             error_logger.exception(exception)
             logger.error(
-                "The error response won't be sent to the client for the "
-                f"{exception} because a previous response has "
+                "The error response won't be sent to the client for the exception: "
+                f"\"{exception}\" because a previous response has "
                 "already been sent at least partially."
             )
             return

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -1292,10 +1292,10 @@ class Sanic(BaseSanic, metaclass=TouchUpMeta):
         response: BaseHTTPResponse,
         request_name: Optional[str] = None,
     ):  # no cov
-        if response.middlewares_ran:
+        if response.middlewares_executed:
             return response
         else:
-            response.middlewares_ran = True
+            response.middlewares_executed = True
         named_middleware = self.named_response_middleware.get(
             request_name, deque()
         )

--- a/sanic/exceptions.py
+++ b/sanic/exceptions.py
@@ -266,3 +266,7 @@ def abort(status_code: int, message: Optional[Union[str, bytes]] = None):
     )
 
     raise SanicException(message=message, status_code=status_code)
+
+
+class ResponseException(SanicException):
+    pass

--- a/sanic/exceptions.py
+++ b/sanic/exceptions.py
@@ -266,14 +266,3 @@ def abort(status_code: int, message: Optional[Union[str, bytes]] = None):
     )
 
     raise SanicException(message=message, status_code=status_code)
-
-
-class ShouldNotHandleException(SanicException):
-    pass
-
-
-class ResponseException(ShouldNotHandleException):
-    """
-    Can be used when the response has already been sent and 500 error response
-    page won't be generated.
-    """

--- a/sanic/exceptions.py
+++ b/sanic/exceptions.py
@@ -266,3 +266,14 @@ def abort(status_code: int, message: Optional[Union[str, bytes]] = None):
     )
 
     raise SanicException(message=message, status_code=status_code)
+
+
+class ShouldNotHandleException(SanicException):
+    pass
+
+
+class ResponseException(ShouldNotHandleException):
+    """
+    Can be used when the response has already been sent and 500 error response
+    page won't be generated.
+    """

--- a/sanic/http.py
+++ b/sanic/http.py
@@ -15,6 +15,7 @@ from sanic.exceptions import (
     HeaderExpectationFailed,
     InvalidUsage,
     PayloadTooLarge,
+    SanicException,
     ServerError,
     ServiceUnavailable,
 )
@@ -589,6 +590,10 @@ class Http(metaclass=TouchUpMeta):
 
     @property
     def send(self):
+        if self.response_func is None and self.stage == Stage.IDLE:
+            raise SanicException(
+                "Response stream was ended, no more response data is allowed to be sent."
+            )
         return self.response_func
 
     @classmethod

--- a/sanic/http.py
+++ b/sanic/http.py
@@ -15,7 +15,6 @@ from sanic.exceptions import (
     HeaderExpectationFailed,
     InvalidUsage,
     PayloadTooLarge,
-    SanicException,
     ServerError,
     ServiceUnavailable,
 )

--- a/sanic/http.py
+++ b/sanic/http.py
@@ -590,10 +590,6 @@ class Http(metaclass=TouchUpMeta):
 
     @property
     def send(self):
-        if self.response_func is None and self.stage == Stage.IDLE:
-            raise SanicException(
-                "Response stream was ended, no more response data is allowed to be sent."
-            )
         return self.response_func
 
     @classmethod

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -32,7 +32,7 @@ from httptools import parse_url  # type: ignore
 
 from sanic.compat import CancelledErrors, Header
 from sanic.constants import DEFAULT_HTTP_CONTENT_TYPE
-from sanic.exceptions import InvalidUsage
+from sanic.exceptions import InvalidUsage, SanicException
 from sanic.headers import (
     AcceptContainer,
     Options,
@@ -175,9 +175,9 @@ class Request:
         content_type: Optional[str] = None,
     ):
         if self.response:
-            logger.warning(
-                "Another response instance was created before, please consider "
-                "re-use it rather than creating a new one."
+            raise SanicException(
+                "Another response instance was created, "
+                "creating the second response is not allowed for this request."
             )
         # This logic of determining which response to use is subject to change
         if response is None:

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -179,7 +179,7 @@ class Request:
                 headers=headers,
                 content_type=content_type,
             )
-        
+
         # Check the status of current stream and response.
         re_use_res = False
         try:

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -183,11 +183,12 @@ class Request:
         # Check the status of current stream and response.
         re_use_res = False
         try:
-            if self.stream.stage is Stage.IDLE:
-                raise ResponseException(
-                    "Another response was sent previously."
-                )
-            re_use_res = response is (self.stream and self.stream.response)
+            if self.stream is not None:
+                if self.stream.stage is Stage.IDLE:
+                    raise ResponseException(
+                        "Another response was sent previously."
+                    )
+                re_use_res = response is (self.stream and self.stream.response)
         except AttributeError:
             pass
 

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -31,7 +31,7 @@ from httptools import parse_url  # type: ignore
 
 from sanic.compat import CancelledErrors, Header
 from sanic.constants import DEFAULT_HTTP_CONTENT_TYPE
-from sanic.exceptions import InvalidUsage, SanicException
+from sanic.exceptions import InvalidUsage, ResponseException
 from sanic.headers import (
     AcceptContainer,
     Options,
@@ -173,9 +173,7 @@ class Request:
         content_type: Optional[str] = None,
     ):
         if isinstance(self.stream, Http) and self.stream.stage is Stage.IDLE:
-            raise SanicException(
-                "Another response was sent previously."
-            )
+            raise ResponseException("Another response was sent previously.")
         # This logic of determining which response to use is subject to change
         if response is None:
             response = (self.stream and self.stream.response) or HTTPResponse(

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -31,7 +31,7 @@ from httptools import parse_url  # type: ignore
 
 from sanic.compat import CancelledErrors, Header
 from sanic.constants import DEFAULT_HTTP_CONTENT_TYPE
-from sanic.exceptions import InvalidUsage
+from sanic.exceptions import InvalidUsage, SanicException
 from sanic.headers import (
     AcceptContainer,
     Options,
@@ -172,7 +172,10 @@ class Request:
         headers: Optional[Union[Header, Dict[str, str]]] = None,
         content_type: Optional[str] = None,
     ):
-
+        if isinstance(self.stream, Http) and self.stream.stage is Stage.IDLE:
+            raise SanicException(
+                "Another response was sent previously."
+            )
         # This logic of determining which response to use is subject to change
         if response is None:
             response = (self.stream and self.stream.response) or HTTPResponse(

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -109,6 +109,7 @@ class Request:
         "stream",
         "transport",
         "version",
+        "response",
     )
 
     def __init__(
@@ -149,6 +150,7 @@ class Request:
         self.parsed_not_grouped_args: DefaultDict[
             Tuple[bool, bool, str, str], List[Tuple[str, str]]
         ] = defaultdict(list)
+        self.response: Optional[BaseHTTPResponse] = None
         self.request_middleware_started = False
         self._cookies: Optional[Dict[str, str]] = None
         self._match_info: Dict[str, Any] = {}
@@ -172,6 +174,11 @@ class Request:
         headers: Optional[Union[Header, Dict[str, str]]] = None,
         content_type: Optional[str] = None,
     ):
+        if self.response:
+            logger.warning(
+                "Another response instance was created before, please consider "
+                "re-use it rather than creating a new one."
+            )
         # This logic of determining which response to use is subject to change
         if response is None:
             response = (self.stream and self.stream.response) or HTTPResponse(
@@ -193,6 +200,7 @@ class Request:
             error_logger.exception(
                 "Exception occurred in one of response middleware handlers"
             )
+        self.response = response
         return response
 
     async def receive_body(self):

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -189,16 +189,7 @@ class Request:
                     if self.stream.stage in (Stage.RESPONSE, Stage.IDLE)
                     else SanicException
                 )
-                raise exception(
-                    "Another response was created for this request. "
-                    "Creating the second response is not allowed. "
-                    "The response of this request can be reset if not yet "
-                    "sent."
-                )
-            if self.stream.stage in (Stage.RESPONSE, Stage.IDLE):
-                raise ResponseException(
-                    "Cannot send response to this request twice."
-                )
+                raise exception("Cannot send response to this request twice.")
         # This logic of determining which response to use is subject to change
         if response is None:
             response = (self.stream and self.stream.response) or HTTPResponse(

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -31,7 +31,7 @@ from httptools import parse_url  # type: ignore
 
 from sanic.compat import CancelledErrors, Header
 from sanic.constants import DEFAULT_HTTP_CONTENT_TYPE
-from sanic.exceptions import InvalidUsage, ResponseException, SanicException
+from sanic.exceptions import InvalidUsage
 from sanic.headers import (
     AcceptContainer,
     Options,
@@ -164,15 +164,6 @@ class Request:
     def generate_id(*_):
         return uuid.uuid4()
 
-    def reset_response(self):
-        if isinstance(self.stream, Http):
-            if self.stream.stage in (Stage.RESPONSE, Stage.IDLE):
-                raise ResponseException(
-                    "Response can't be reset because it was already sent."
-                )
-            elif self.stream.response:
-                self.stream.response = None
-
     async def respond(
         self,
         response: Optional[BaseHTTPResponse] = None,
@@ -182,14 +173,6 @@ class Request:
         content_type: Optional[str] = None,
     ):
 
-        if isinstance(self.stream, Http):
-            if self.stream.response:
-                exception = (
-                    ResponseException
-                    if self.stream.stage in (Stage.RESPONSE, Stage.IDLE)
-                    else SanicException
-                )
-                raise exception("Cannot send response to this request twice.")
         # This logic of determining which response to use is subject to change
         if response is None:
             response = (self.stream and self.stream.response) or HTTPResponse(

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -175,14 +175,17 @@ class Request:
         if isinstance(self.stream, Http) and self.stream.stage is Stage.IDLE:
             raise ResponseException("Another response was sent previously.")
         # This logic of determining which response to use is subject to change
-        re_use_res = False
         if response is None:
             response = (self.stream and self.stream.response) or HTTPResponse(
                 status=status,
                 headers=headers,
                 content_type=content_type,
             )
-            re_use_res = response is (self.stream and self.stream.response)
+        re_use_res = (
+            response is (self.stream and self.stream.response)
+            if isinstance(self.stream, Http)
+            else False
+        )
         # Connect the response
         if isinstance(response, BaseHTTPResponse) and self.stream:
             response = self.stream.respond(response)

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -101,7 +101,7 @@ class BaseHTTPResponse:
 
     async def send(
         self,
-        data: Optional[Union[AnyStr]] = None,
+        data: Optional[AnyStr] = None,
         end_stream: Optional[bool] = None,
     ) -> None:
         """

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -19,7 +19,7 @@ from warnings import warn
 from sanic.compat import Header, open_async
 from sanic.constants import DEFAULT_HTTP_CONTENT_TYPE
 from sanic.cookies import CookieJar
-from sanic.exceptions import SanicException
+from sanic.exceptions import ResponseException, SanicException
 from sanic.helpers import has_message_body, remove_entity_headers
 from sanic.http import Http, Stage
 from sanic.models.protocol_types import HTMLProtocol, Range
@@ -118,9 +118,9 @@ class BaseHTTPResponse:
             if end_stream and not data:
                 return
             elif self.stream.stage == Stage.IDLE:
-                raise SanicException(
+                raise ResponseException(
                     "Response stream was ended, no more response data is"
-                    " allow ed to be sent."
+                    " allowed to be sent."
                 )
             else:
                 raise SanicException("Send response function isn't available")

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -50,7 +50,6 @@ class BaseHTTPResponse:
         self.status: int = None
         self.headers = Header({})
         self._cookies: Optional[CookieJar] = None
-        self.middlewares_executed: bool = False
 
     def _encode_body(self, data: Optional[AnyStr]):
         if data is None:

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -19,7 +19,7 @@ from warnings import warn
 from sanic.compat import Header, open_async
 from sanic.constants import DEFAULT_HTTP_CONTENT_TYPE
 from sanic.cookies import CookieJar
-from sanic.exceptions import SanicException
+from sanic.exceptions import ResponseException, SanicException
 from sanic.helpers import has_message_body, remove_entity_headers
 from sanic.http import Http, Stage
 from sanic.models.protocol_types import HTMLProtocol, Range
@@ -117,9 +117,12 @@ class BaseHTTPResponse:
             if end_stream and not data:
                 return
             elif self.stream.stage == Stage.IDLE:
-                raise SanicException(
-                    "Response stream was ended, no more response data is allowed to be sent."
+                raise ResponseException(
+                    "Response stream was ended, no more response data is"
+                    " allow ed to be sent."
                 )
+            else:
+                raise SanicException("Send response function isn't available")
         data = (
             data.encode()  # type: ignore
             if hasattr(data, "encode")

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -119,8 +119,8 @@ class BaseHTTPResponse:
                 return
             elif self.stream.stage == Stage.IDLE:
                 raise ResponseException(
-                    "Response stream was ended, no more response data is"
-                    " allowed to be sent."
+                    "Response stream was ended, no more response data is "
+                    "allowed to be sent."
                 )
             else:
                 raise SanicException("Send response function isn't available")

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -50,7 +50,7 @@ class BaseHTTPResponse:
         self.status: int = None
         self.headers = Header({})
         self._cookies: Optional[CookieJar] = None
-        self.middlewares_ran: bool = True
+        self.middlewares_executed: bool = False
 
     def _encode_body(self, data: Optional[AnyStr]):
         if data is None:

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -19,7 +19,7 @@ from warnings import warn
 from sanic.compat import Header, open_async
 from sanic.constants import DEFAULT_HTTP_CONTENT_TYPE
 from sanic.cookies import CookieJar
-from sanic.exceptions import ResponseException, SanicException
+from sanic.exceptions import SanicException
 from sanic.helpers import has_message_body, remove_entity_headers
 from sanic.http import Http, Stage
 from sanic.models.protocol_types import HTMLProtocol, Range
@@ -50,6 +50,7 @@ class BaseHTTPResponse:
         self.status: int = None
         self.headers = Header({})
         self._cookies: Optional[CookieJar] = None
+        self.middlewares_ran: bool = True
 
     def _encode_body(self, data: Optional[AnyStr]):
         if data is None:
@@ -117,7 +118,7 @@ class BaseHTTPResponse:
             if end_stream and not data:
                 return
             elif self.stream.stage == Stage.IDLE:
-                raise ResponseException(
+                raise SanicException(
                     "Response stream was ended, no more response data is"
                     " allow ed to be sent."
                 )

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -297,3 +297,28 @@ def test_middleware_added_response(app):
 
     _, response = app.test_client.get("/")
     assert response.json["foo"] == "bar"
+
+
+def test_middleware_added_response(app):
+    response_middleware_run_count = 0
+    request_middleware_run_count = 0
+
+    @app.on_response
+    def response(_, response):
+        nonlocal response_middleware_run_count
+        response_middleware_run_count += 1
+
+    @app.on_request
+    def request(_):
+        nonlocal request_middleware_run_count
+        request_middleware_run_count += 1
+
+    @app.get("/")
+    async def handler(request):
+        resp1 = await request.respond()
+        await resp1.eof()
+        return text("")
+
+    _, response = app.test_client.get("/")
+    assert response_middleware_run_count == 1
+    assert request_middleware_run_count == 1

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -299,7 +299,7 @@ def test_middleware_added_response(app):
     assert response.json["foo"] == "bar"
 
 
-def test_middleware_added_response(app):
+def test_middleware_return_response(app):
     response_middleware_run_count = 0
     request_middleware_run_count = 0
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -316,8 +316,7 @@ def test_middleware_added_response(app):
     @app.get("/")
     async def handler(request):
         resp1 = await request.respond()
-        resp2 = await request.respond()
-        await resp1.eof()
+        return resp1
 
     _, response = app.test_client.get("/")
     assert response_middleware_run_count == 1

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -316,8 +316,8 @@ def test_middleware_added_response(app):
     @app.get("/")
     async def handler(request):
         resp1 = await request.respond()
+        resp2 = await request.respond()
         await resp1.eof()
-        return text("")
 
     _, response = app.test_client.get("/")
     assert response_middleware_run_count == 1

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2177,10 +2177,6 @@ def test_handler_overload(app):
 
 
 def test_second_response(app):
-    @app.exception(ServerError)
-    def handler_exception(request, exception):
-        return text("Internal Server Error.", 500)
-
     @app.get("/")
     async def two_responses(request: Request):
         resp1 = await request.respond()
@@ -2192,10 +2188,6 @@ def test_second_response(app):
 
 @pytest.mark.asyncio
 async def test_second_response_asgi(app):
-    @app.exception(ServerError)
-    def handler_exception(request, exception):
-        return text("Internal Server Error.", 500)
-
     @app.get("/")
     async def two_responses(request: Request):
         resp1 = await request.respond()

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2174,4 +2174,3 @@ def test_handler_overload(app):
     _, response = app.test_client.post("/long/sub/route")
     assert response.status == 200
     assert response.json == {}
-

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -15,7 +15,7 @@ from sanic_testing.testing import (
 )
 
 from sanic import Blueprint, Sanic
-from sanic.exceptions import ServerError
+from sanic.exceptions import SanicException, ServerError
 from sanic.request import DEFAULT_HTTP_CONTENT_TYPE, Request, RequestParameters
 from sanic.response import html, json, text
 
@@ -2175,25 +2175,3 @@ def test_handler_overload(app):
     assert response.status == 200
     assert response.json == {}
 
-
-def test_second_response(app):
-    @app.get("/")
-    async def two_responses(request: Request):
-        resp1 = await request.respond()
-        resp1.send("some msg")
-        resp2 = await request.respond()
-
-    request, response = app.test_client.get("/")
-    assert response.status == 500
-
-
-@pytest.mark.asyncio
-async def test_second_response_asgi(app):
-    @app.get("/")
-    async def two_responses(request: Request):
-        resp1 = await request.respond()
-        resp1.send("some msg")
-        resp2 = await request.respond()
-
-    request, response = await app.asgi_client.get("/")
-    assert response.status == 500

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -2180,6 +2180,7 @@ def test_second_response(app):
     @app.get("/")
     async def two_responses(request: Request):
         resp1 = await request.respond()
+        resp1.send("some msg")
         resp2 = await request.respond()
 
     request, response = app.test_client.get("/")
@@ -2191,6 +2192,7 @@ async def test_second_response_asgi(app):
     @app.get("/")
     async def two_responses(request: Request):
         resp1 = await request.respond()
+        resp1.send("some msg")
         resp2 = await request.respond()
 
     request, response = await app.asgi_client.get("/")


### PR DESCRIPTION
Trying to solve issue: https://github.com/sanic-org/sanic/issues/2219

Some doubts I still have:
1. Whether it's okay to put a `response` reference in `request` instance. I recently learned from the memory leak issue; we should not create more reference if not necessary. I am considering replace it with a bool flag. 
2. Should we only allow one response instance for each request? If so, we can consider keep and cache the response reference and return it if `request.respond` method is called more than 1 time.
3. I believe that `self.response_func is None and self.stage == Stage.IDLE` implies the request has been responded and the response stream is ended. Am I correct on this?

Please let me know your suggestions, thanks! @sanic-org/core-devs 