### PR TITLE
Allow underscore to start instance names

### DIFF
--- a/sanic/base.py
+++ b/sanic/base.py
@@ -11,7 +11,7 @@ from sanic.mixins.routes import RouteMixin
 from sanic.mixins.signals import SignalMixin
 
 
-VALID_NAME = re.compile(r"^[a-zA-Z][a-zA-Z0-9_\-]*$")
+VALID_NAME = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_\-]*$")
 
 
 class BaseSanic(


### PR DESCRIPTION
This is to allow `__main__` to be valid and not raise an error.