### PR TITLE
Add pre-registry

### DIFF
--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -107,6 +107,7 @@ class Blueprint(BaseSanic):
         "version_prefix",
         "websocket_routes",
     )
+    __pre_registry__: Dict[str, Any] = {}
 
     def __init__(
         self,
@@ -461,3 +462,25 @@ class Blueprint(BaseSanic):
     ):
         for app in apps:
             app._future_registry.update(set((bp, item) for item in futures))
+
+    def pre_register(
+        self,
+        name: str = None,
+        url_prefix: Optional[str] = None,
+        host: Optional[Union[List[str], str]] = None,
+        version: Optional[Union[int, str, float]] = None,
+        strict_slashes: Optional[bool] = None,
+        version_prefix: Union[str, Default] = _default,
+    ) -> None:
+        self.__class__.__pre_registry__[name] = {
+            k: v
+            for k, v in {
+                "bp": self,
+                "url_prefix": url_prefix,
+                "host": host,
+                "version": version,
+                "strict_slashes": strict_slashes,
+                "version_prefix": version_prefix,
+            }.items()
+            if v is not None and v is not _default
+        }


### PR DESCRIPTION
I see a lot of developers getting stuck because of import ordering. While I think there are some helpful patterns to avoid this, it might also be helpful to provide a little leeway. This PR is meant to add:

```python
bp.pre_register("SomeAppName")
```

Then, upon application startup, all preregistered blueprints will automatically be loaded.