### PR TITLE
Fixed task is created again when adding the task

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -1552,16 +1552,17 @@ class Sanic(BaseSanic, metaclass=TouchUpMeta):
         name: Optional[str] = None,
         register: bool = True,
     ) -> Task:
-        prepped = cls._prep_task(task, app, loop)
-        if sys.version_info == (3, 7):
-            if name:
-                error_logger.warning(
-                    "Cannot set a name for a task when using Python 3.7. Your "
-                    "task will be created without a name."
-                )
-            task = loop.create_task(prepped)
-        else:
-            task = loop.create_task(prepped, name=name)
+        if not isinstance(task, Future):
+            prepped = cls._prep_task(task, app, loop)
+            if sys.version_info == (3, 7):
+                if name:
+                    error_logger.warning(
+                        "Cannot set a name for a task when using Python 3.7. Your "
+                        "task will be created without a name."
+                    )
+                task = loop.create_task(prepped)
+            else:
+                task = loop.create_task(prepped, name=name)
 
         if name and register:
             app._task_registry[name] = task


### PR DESCRIPTION
Before this PR, even if a task or a future was received, the task was created and registered once again.
When a user gives a task or future, only the task is added without creating a task or future again.