### PR TITLE
fix(tasks): newly assigned ``None`` in registry

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -1179,6 +1179,8 @@ class Sanic(BaseSanic, RunnerMixin, metaclass=TouchUpMeta):
                 task = loop.create_task(prepped, name=name)
 
         if name and register and sys.version_info > (3, 7):
+            if isinstance(task, Task):
+                task.set_name(name)
             app._task_registry[name] = task
 
         return task

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -1179,8 +1179,6 @@ class Sanic(BaseSanic, RunnerMixin, metaclass=TouchUpMeta):
                 task = loop.create_task(prepped, name=name)
 
         if name and register and sys.version_info > (3, 7):
-            if isinstance(task, Task):
-                task.set_name(name)
             app._task_registry[name] = task
 
         return task
@@ -1270,10 +1268,9 @@ class Sanic(BaseSanic, RunnerMixin, metaclass=TouchUpMeta):
                 ...
 
     def purge_tasks(self):
-        for task in self.tasks:
+        for key, task in self._task_registry.items():
             if task.done() or task.cancelled():
-                name = task.get_name()
-                self._task_registry[name] = None
+                self._task_registry[key] = None
 
         self._task_registry = {
             k: v for k, v in self._task_registry.items() if v is not None

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -80,6 +80,18 @@ async def test_purge_tasks(app: Sanic):
     assert len(app._task_registry) == 0
 
 
+async def test_purge_tasks_with_create_task(app: Sanic):
+    app.add_task(asyncio.create_task(dummy(3)), name="dummy")
+
+    await app.cancel_task("dummy")
+
+    assert len(app._task_registry) == 1
+
+    app.purge_tasks()
+
+    assert len(app._task_registry) == 0
+
+
 def test_shutdown_tasks_on_app_stop():
     class TestSanic(Sanic):
         shutdown_tasks = Mock()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -79,16 +79,6 @@ async def test_purge_tasks(app: Sanic):
 
     assert len(app._task_registry) == 0
 
-async def test_purge_tasks_when_create_task(app: Sanic):
-    app.add_task(asyncio.create_task(dummy(3)), name="dummy")
-
-    await app.cancel_task("dummy")
-
-    assert len(app._task_registry) == 1
-
-    app.purge_tasks()
-
-    assert len(app._task_registry) == 0
 
 def test_shutdown_tasks_on_app_stop():
     class TestSanic(Sanic):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -79,6 +79,16 @@ async def test_purge_tasks(app: Sanic):
 
     assert len(app._task_registry) == 0
 
+async def test_purge_tasks_when_create_task(app: Sanic):
+    app.add_task(asyncio.create_task(dummy(3)), name="dummy")
+
+    await app.cancel_task("dummy")
+
+    assert len(app._task_registry) == 1
+
+    app.purge_tasks()
+
+    assert len(app._task_registry) == 0
 
 def test_shutdown_tasks_on_app_stop():
     class TestSanic(Sanic):


### PR DESCRIPTION
## How to reproduce?
```python
from sanic import Sanic
from asyncio import sleep, create_task

app = Sanic(__name__)


async def task():
    while True:
        await sleep(10)


@app.before_server_start
async def dummy_start(app, _):
    app.add_task(create_task(task()), name="Dummy")


@app.before_server_stop
async def dummy_stop(app, _):
    # Raise RuntimeError: dictionary changed size during iteration
    app.purge_tasks()


app.run()
```
https://github.com/sanic-org/sanic/blob/b8d991420b698ca18d18c8893a219a0d0e9e55c9/sanic/app.py#L1273-L1274
If a name is not registered during create_task, the following name is obtained as ``Task-1``, so the error that occurred because it is newly assigned has been resolved.