### PR TITLE
remove overlapping slots from app.Sanic, fix broken slots inherit of HTTPResponse

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -140,6 +140,7 @@ To maintain the code consistency, Sanic uses following tools.
 #. `isort <https://github.com/timothycrosley/isort>`_
 #. `black <https://github.com/python/black>`_
 #. `flake8 <https://github.com/PyCQA/flake8>`_
+#. `slotscheck <https://github.com/ariebovenberg/slotscheck>`_
 
 isort
 *****
@@ -167,7 +168,13 @@ flake8
 #. pycodestyle
 #. Ned Batchelder's McCabe script
 
-``isort``\ , ``black`` and ``flake8`` checks are performed during ``tox`` lint checks.
+slotscheck
+**********
+
+``slotscheck`` ensures that there are no problems with ``__slots__``
+(e.g. overlaps, or missing slots in base classes).
+
+``isort``\ , ``black``\ , ``flake8`` and ``slotscheck`` checks are performed during ``tox`` lint checks.
 
 The **easiest** way to make your code conform is to run the following before committing.
 

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -142,7 +142,6 @@ class Sanic(BaseSanic, RunnerMixin, metaclass=TouchUpMeta):
         "error_handler",
         "go_fast",
         "listeners",
-        "name",
         "named_request_middleware",
         "named_response_middleware",
         "request_class",

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -50,6 +50,16 @@ class BaseHTTPResponse:
     The base class for all HTTP Responses
     """
 
+    __slots__ = (
+        "asgi",
+        "body",
+        "content_type",
+        "stream",
+        "status",
+        "headers",
+        "_cookies",
+    )
+
     _dumps = json_dumps
 
     def __init__(self):
@@ -156,7 +166,7 @@ class HTTPResponse(BaseHTTPResponse):
     :type content_type: Optional[str]
     """
 
-    __slots__ = ("body", "status", "content_type", "headers", "_cookies")
+    __slots__ = ()
 
     def __init__(
         self,

--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,7 @@ tests_require = [
     "docutils",
     "pygments",
     "uvicorn<0.15.0",
+    "slotscheck>=0.8.0,<1",
     types_ujson,
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ commands =
     flake8 sanic
     black --config ./.black.toml --check --verbose sanic/
     isort --check-only sanic --profile=black
+    slotscheck --verbose -m sanic
 
 [testenv:type-checking]
 commands =


### PR DESCRIPTION
# Summary

There are some `__slots__`-related problems in `sanic`:

```shell
$ slotscheck -m sanic -v
ERROR: 'sanic.app:Sanic' defines overlapping slots.
       - name (sanic.base.root:BaseSanic)
ERROR: 'sanic.response:HTTPResponse' has slots but superclass does not.
       - sanic.response:BaseHTTPResponse
```

- Fixing the slot overlap saves a bit of wasted space
- Fixing the broken slots inheritance ensures `HTTPResponse` won't get a `__dict__` and saves a bit of memory in the process.

# Questions

regarding tests: probably not needed. I discovered the slots issue with [slotscheck](https://github.com/ariebovenberg/slotscheck), a tool I maintain. Of course, If you like, I can add it to tox/CI as I've done for [instagram/LibCST](https://github.com/Instagram/LibCST/pull/615) and [dry-python/returns](https://github.com/dry-python/returns/pull/1233).
