### PR TITLE
Fix "DeprecationWarning: There is no current event loop"

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -11,7 +11,6 @@ from asyncio import (
     CancelledError,
     Task,
     ensure_future,
-    get_event_loop,
     get_event_loop_policy,
     get_running_loop,
     wait_for,

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -12,6 +12,7 @@ from asyncio import (
     Task,
     ensure_future,
     get_event_loop,
+    get_event_loop_policy,
     get_running_loop,
     wait_for,
 )
@@ -254,7 +255,7 @@ class Sanic(BaseSanic, RunnerMixin, metaclass=TouchUpMeta):
                 "Loop can only be retrieved after the app has started "
                 "running. Not supported with `create_server` function"
             )
-        return get_event_loop()
+        return get_event_loop_policy().get_event_loop()
 
     # -------------------------------------------------------------------- #
     # Registration


### PR DESCRIPTION
I'm seeing the warning on Windows platforms only but it is a general deprecation of Python 3.10, to be dropped for 3.11