### PR TITLE
allow multidict version 6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ requirements = [
     ujson,
     "aiofiles>=0.6.0",
     "websockets>=10.0",
-    "multidict>=5.0,<6.0",
+    "multidict>=5.0,<7.0",
 ]
 
 tests_require = [


### PR DESCRIPTION
The only breaking change is the dropped support for Python 3.6, which sanic doesn't support anyway: https://github.com/aio-libs/multidict/releases/tag/v6.0.0