### PR TITLE
Document middleware `on_request` and `on_response`

### DIFF
--- a/sanic/mixins/middleware.py
+++ b/sanic/mixins/middleware.py
@@ -17,7 +17,7 @@ class MiddlewareMixin(metaclass=SanicMeta):
     ):
         """
         Decorate and register middleware to be called before a request
-        is handled or a response sent. Can either be called as
+        is handled or after a response is created. Can either be called as
         *@app.middleware* or *@app.middleware('request')*.
 
         `See user guide re: middleware
@@ -59,7 +59,7 @@ class MiddlewareMixin(metaclass=SanicMeta):
             return partial(self.middleware, attach_to="request")
 
     def on_response(self, middleware=None):
-        """Register a middleware to be called before a response is sent.
+        """Register a middleware to be called after a response is created.
 
         This is the same as *@app.middleware('response')*.
 

--- a/sanic/mixins/middleware.py
+++ b/sanic/mixins/middleware.py
@@ -63,7 +63,8 @@ class MiddlewareMixin(metaclass=SanicMeta):
 
         This is the same as *@app.middleware('response')*.
 
-        :param: middleware: A callable that takes in a request and its response.
+        :param: middleware:
+            A callable that takes in a request and its response.
         """
         if callable(middleware):
             return self.middleware(middleware, "response")

--- a/sanic/mixins/middleware.py
+++ b/sanic/mixins/middleware.py
@@ -63,7 +63,7 @@ class MiddlewareMixin(metaclass=SanicMeta):
 
         This is the same as *@app.middleware('response')*.
 
-        :param: middleware: A callable that takes in a response.
+        :param: middleware: A callable that takes in a request and its response.
         """
         if callable(middleware):
             return self.middleware(middleware, "response")

--- a/sanic/mixins/middleware.py
+++ b/sanic/mixins/middleware.py
@@ -16,9 +16,9 @@ class MiddlewareMixin(metaclass=SanicMeta):
         self, middleware_or_request, attach_to="request", apply=True
     ):
         """
-        Decorate and register middleware to be called before a request.
-        Can either be called as *@app.middleware* or
-        *@app.middleware('request')*
+        Decorate and register middleware to be called before a request
+        is handled or a response sent. Can either be called as
+        *@app.middleware* or *@app.middleware('request')*.
 
         `See user guide re: middleware
         <https://sanicframework.org/guide/basics/middleware.html>`__
@@ -47,12 +47,24 @@ class MiddlewareMixin(metaclass=SanicMeta):
             )
 
     def on_request(self, middleware=None):
+        """Register a middleware to be called before a request is handled.
+
+        This is the same as *@app.middleware('request')*.
+
+        :param: middleware: A callable that takes in request.
+        """
         if callable(middleware):
             return self.middleware(middleware, "request")
         else:
             return partial(self.middleware, attach_to="request")
 
     def on_response(self, middleware=None):
+        """Register a middleware to be called before a response is sent.
+
+        This is the same as *@app.middleware('response')*.
+
+        :param: middleware: A callable that takes in a response.
+        """
         if callable(middleware):
             return self.middleware(middleware, "response")
         else:


### PR DESCRIPTION
## Summary

When looking through the documentation I was unable to find these two methods, without docstrings these methods do not show up in the autogenerated documentation.

---

There's not much more to say about this change.
