### PR TITLE
Conditionally inject CLI arguments into factory

### DIFF
--- a/sanic/cli/app.py
+++ b/sanic/cli/app.py
@@ -120,7 +120,10 @@ Or, a path to a directory to run as a simple HTTP server:
                 module = import_module(module_name)
                 app = getattr(module, app_name, None)
                 if self.args.factory:
-                    app = app()
+                    try:
+                        app = app(self.args)
+                    except TypeError:
+                        app = app()
 
                 app_type_name = type(app).__name__
 


### PR DESCRIPTION
When starting with `--factory`, the CLI will attempt to inject the CLI arguments `Namespace` into the factory (if possible).