### PR TITLE
Upgrade tests for sanic-routing changes

### DIFF
--- a/examples/delayed_response.py
+++ b/examples/delayed_response.py
@@ -11,7 +11,7 @@ async def handler(request):
     return response.redirect("/sleep/3")
 
 
-@app.get("/sleep/<t:number>")
+@app.get("/sleep/<t:float>")
 async def handler2(request, t=0.3):
     await sleep(t)
     return response.text(f"Slept {t:.1f} seconds.\n")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -254,7 +254,7 @@ def test_route_strict_slash(app):
 
 
 def test_route_invalid_parameter_syntax(app):
-    with pytest.raises(InvalidUsage):
+    with pytest.raises(ValueError):
 
         @app.get("/get/<:str>", strict_slashes=True)
         def handler(request):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,8 +1,6 @@
 import asyncio
 import re
 
-from unittest.mock import Mock
-
 import pytest
 
 from sanic_routing.exceptions import (
@@ -256,7 +254,7 @@ def test_route_strict_slash(app):
 
 
 def test_route_invalid_parameter_syntax(app):
-    with pytest.raises(ValueError):
+    with pytest.raises(InvalidUsage):
 
         @app.get("/get/<:str>", strict_slashes=True)
         def handler(request):


### PR DESCRIPTION
Recent changes in `sanic-routing` throw a different error on a bad path parameter declaration.