### PR TITLE
Remove loop as required listener arg

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -1131,7 +1131,10 @@ class Sanic(BaseSanic, RunnerMixin, metaclass=TouchUpMeta):
     async def _listener(
         app: Sanic, loop: AbstractEventLoop, listener: ListenerType
     ):
-        maybe_coro = listener(app, loop)
+        try:
+            maybe_coro = listener(app)  # type: ignore
+        except TypeError:
+            maybe_coro = listener(app, loop)  # type: ignore
         if maybe_coro and isawaitable(maybe_coro):
             await maybe_coro
 

--- a/sanic/mixins/runner.py
+++ b/sanic/mixins/runner.py
@@ -548,12 +548,12 @@ class RunnerMixin(metaclass=SanicMeta):
             and os.environ.get("SANIC_SERVER_RUNNING") != "true"
         ):  # no cov
             loop = new_event_loop()
-            trigger_events(reloader_start, loop)
+            trigger_events(reloader_start, loop, primary)
             reload_dirs: Set[Path] = primary.state.reload_dirs.union(
                 *(app.state.reload_dirs for app in apps)
             )
             reloader_helpers.watchdog(1.0, reload_dirs)
-            trigger_events(reloader_stop, loop)
+            trigger_events(reloader_stop, loop, primary)
             return
 
         # This exists primarily for unit testing

--- a/sanic/models/handler_types.py
+++ b/sanic/models/handler_types.py
@@ -18,8 +18,9 @@ ErrorMiddlewareType = Callable[
     [Request, BaseException], Optional[Coroutine[Any, Any, None]]
 ]
 MiddlewareType = Union[RequestMiddlewareType, ResponseMiddlewareType]
-ListenerType = Callable[
-    [Sanic, AbstractEventLoop], Optional[Coroutine[Any, Any, None]]
+ListenerType = Union[
+    Callable[[Sanic], Optional[Coroutine[Any, Any, None]]],
+    Callable[[Sanic, AbstractEventLoop], Optional[Coroutine[Any, Any, None]]],
 ]
 RouteHandler = Callable[..., Coroutine[Any, Any, Optional[HTTPResponse]]]
 SignalHandler = Callable[..., Coroutine[Any, Any, None]]

--- a/sanic/server/events.py
+++ b/sanic/server/events.py
@@ -1,8 +1,18 @@
+from __future__ import annotations
+
 from inspect import isawaitable
-from typing import Any, Callable, Iterable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional
 
 
-def trigger_events(events: Optional[Iterable[Callable[..., Any]]], loop):
+if TYPE_CHECKING:
+    from sanic import Sanic
+
+
+def trigger_events(
+    events: Optional[Iterable[Callable[..., Any]]],
+    loop,
+    app: Optional[Sanic] = None,
+):
     """
     Trigger event callbacks (functions or async)
 
@@ -11,6 +21,9 @@ def trigger_events(events: Optional[Iterable[Callable[..., Any]]], loop):
     """
     if events:
         for event in events:
-            result = event(loop)
+            try:
+                result = event() if not app else event(app)
+            except TypeError:
+                result = event(loop) if not app else event(app, loop)
             if isawaitable(result):
                 loop.run_until_complete(result)

--- a/sanic/server/events.py
+++ b/sanic/server/events.py
@@ -4,7 +4,7 @@ from inspect import isawaitable
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # no cov
     from sanic import Sanic
 
 

--- a/tests/test_server_events.py
+++ b/tests/test_server_events.py
@@ -33,6 +33,14 @@ def create_listener(listener_name, in_list):
     return _listener
 
 
+def create_listener_no_loop(listener_name, in_list):
+    async def _listener(app):
+        print(f"DEBUG MESSAGE FOR PYTEST for {listener_name}")
+        in_list.insert(0, app.name + listener_name)
+
+    return _listener
+
+
 def start_stop_app(random_name_app, **run_kwargs):
     def stop_on_alarm(signum, frame):
         random_name_app.stop()
@@ -52,6 +60,17 @@ def test_single_listener(app, listener_name):
     output = []
     # Register listener
     app.listener(listener_name)(create_listener(listener_name, output))
+    start_stop_app(app)
+    assert app.name + listener_name == output.pop()
+
+
+@skipif_no_alarm
+@pytest.mark.parametrize("listener_name", AVAILABLE_LISTENERS)
+def test_single_listener_no_loop(app, listener_name):
+    """Test that listeners on their own work"""
+    output = []
+    # Register listener
+    app.listener(listener_name)(create_listener_no_loop(listener_name, output))
     start_stop_app(app)
     assert app.name + listener_name == output.pop()
 


### PR DESCRIPTION
The main change of this PR is to remove `loop` as a required argument for listeners. In most cases now, `loop` should not be necessary. Both of the following will be acceptable:

```python
@app.before_server_start
async def without(app):
    ...

@app.before_server_start
async def with(app, loop):
    ...
```