### PR TITLE
Preserve blank values for form parsing (option)

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -427,7 +427,7 @@ class Request:
         return self.parsed_credentials
 
     @property
-    def form(self):
+    def form(self, keep_blank_values: bool = False):
         if self.parsed_form is None:
             self.parsed_form = RequestParameters()
             self.parsed_files = RequestParameters()
@@ -438,7 +438,7 @@ class Request:
             try:
                 if content_type == "application/x-www-form-urlencoded":
                     self.parsed_form = RequestParameters(
-                        parse_qs(self.body.decode("utf-8"))
+                        parse_qs(self.body.decode("utf-8"), keep_blank_values)
                     )
                 elif content_type == "multipart/form-data":
                     # TODO: Stream this instead of reading to/from memory

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -146,7 +146,7 @@ class Request:
         self.head = head
 
         # enforce existing behavior prior to issue #2427
-        self.keep_blank_values = False
+        self.keep_blank_form_values = False
 
         # Init but do not inhale
         self.body = b""
@@ -431,17 +431,12 @@ class Request:
         return self.parsed_credentials
 
     @property
-    def keep_blank_values(self) -> bool:
-        """Getter for preserving blank form values"""
+    def keep_blank_form_values(self) -> bool:
         return self._keep_blank_form_values
 
-    @keep_blank_values.setter
-    def keep_blank_values(self, keep_blank_values: bool = False):
-        """Setter for preserving blank form values
-
-        Defaults to false
-        """
-        self._keep_blank_form_values = keep_blank_values
+    @keep_blank_form_values.setter
+    def keep_blank_values(self, keep_blank_form_values: bool = False):
+        self._keep_blank_form_values = keep_blank_form_values
 
     @property
     def form(self):
@@ -456,7 +451,7 @@ class Request:
                 if content_type == "application/x-www-form-urlencoded":
                     self.parsed_form = RequestParameters(
                         parse_qs(
-                            self.body.decode("utf-8"), self.keep_blank_values
+                            self.body.decode("utf-8"), self.keep_blank_form_values
                         )
                     )
                 elif content_type == "multipart/form-data":

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -436,7 +436,6 @@ class Request:
         """
         return self._keep_blank_form_values
 
-
     @keep_blank_values.setter
     def keep_blank_values(self, keep_blank_values: bool = False):
         """Setter for preserving blank form values
@@ -444,7 +443,6 @@ class Request:
         Defaults to false
         """
         self._keep_blank_form_values = keep_blank_values
-
 
     @property
     def form(self):
@@ -458,7 +456,8 @@ class Request:
             try:
                 if content_type == "application/x-www-form-urlencoded":
                     self.parsed_form = RequestParameters(
-                        parse_qs(self.body.decode("utf-8"), self.keep_blank_values)
+                        parse_qs(self.body.decode("utf-8"),
+                            self.keep_blank_values)
                     )
                 elif content_type == "multipart/form-data":
                     # TODO: Stream this instead of reading to/from memory

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -432,8 +432,7 @@ class Request:
 
     @property
     def keep_blank_values(self) -> bool:
-        """Getter for preserving blank form values
-        """
+        """Getter for preserving blank form values"""
         return self._keep_blank_form_values
 
     @keep_blank_values.setter
@@ -456,8 +455,9 @@ class Request:
             try:
                 if content_type == "application/x-www-form-urlencoded":
                     self.parsed_form = RequestParameters(
-                        parse_qs(self.body.decode("utf-8"),
-                                    self.keep_blank_values)
+                        parse_qs(
+                            self.body.decode("utf-8"), self.keep_blank_values
+                        )
                     )
                 elif content_type == "multipart/form-data":
                     # TODO: Stream this instead of reading to/from memory

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -146,7 +146,7 @@ class Request:
         self.head = head
 
         # enforce existing behavior prior to issue #2427
-        self._keep_blank_form_values = False
+        self.keep_blank_values = False
 
         # Init but do not inhale
         self.body = b""

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -457,7 +457,7 @@ class Request:
                 if content_type == "application/x-www-form-urlencoded":
                     self.parsed_form = RequestParameters(
                         parse_qs(self.body.decode("utf-8"),
-                            self.keep_blank_values)
+                                    self.keep_blank_values)
                     )
                 elif content_type == "multipart/form-data":
                     # TODO: Stream this instead of reading to/from memory

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -431,6 +431,13 @@ class Request:
         return self.parsed_credentials
 
     @property
+    def keep_blank_values(self) -> bool:
+        """Getter for preserving blank form values
+        """
+        return self._keep_blank_form_values
+
+
+    @keep_blank_values.setter
     def keep_blank_values(self, keep_blank_values: bool = False):
         """Setter for preserving blank form values
 
@@ -438,11 +445,6 @@ class Request:
         """
         self._keep_blank_form_values = keep_blank_values
 
-    @property
-    def keep_blank_values(self) -> bool:
-        """Getter for preserving blank form values
-        """
-        return self._keep_blank_form_values
 
     @property
     def form(self):

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -432,14 +432,20 @@ class Request:
 
     @property
     def keep_blank_values(self, keep_blank_values: bool = False):
+        """Setter for preserving blank form values
+
+        Defaults to false
+        """
         self._keep_blank_form_values = keep_blank_values
 
     @property
     def keep_blank_values(self) -> bool:
+        """Getter for preserving blank form values
+        """
         return self._keep_blank_form_values
 
     @property
-    def form(self) -> RequestParameters:
+    def form(self):
         if self.parsed_form is None:
             self.parsed_form = RequestParameters()
             self.parsed_files = RequestParameters()

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -93,6 +93,7 @@ class Request:
         "_socket",
         "_match_info",
         "_name",
+        "_keep_blank_form_values",
         "app",
         "body",
         "conn_info",
@@ -143,6 +144,9 @@ class Request:
         self.method = method
         self.transport = transport
         self.head = head
+
+        # enforce existing behavior prior to issue #2427
+        self._keep_blank_form_values = False
 
         # Init but do not inhale
         self.body = b""
@@ -427,7 +431,15 @@ class Request:
         return self.parsed_credentials
 
     @property
-    def form(self, keep_blank_values: bool = False):
+    def keep_blank_values(self, keep_blank_values: bool = False):
+        self._keep_blank_form_values = keep_blank_values
+
+    @property
+    def keep_blank_values(self) -> bool:
+        return self._keep_blank_form_values
+
+    @property
+    def form(self) -> RequestParameters:
         if self.parsed_form is None:
             self.parsed_form = RequestParameters()
             self.parsed_files = RequestParameters()
@@ -438,7 +450,7 @@ class Request:
             try:
                 if content_type == "application/x-www-form-urlencoded":
                     self.parsed_form = RequestParameters(
-                        parse_qs(self.body.decode("utf-8"), keep_blank_values)
+                        parse_qs(self.body.decode("utf-8"), self._keep_blank_form_values)
                     )
                 elif content_type == "multipart/form-data":
                     # TODO: Stream this instead of reading to/from memory

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -93,7 +93,7 @@ class Request:
         "_socket",
         "_match_info",
         "_name",
-        "_keep_blank_form_values",
+        "keep_blank_form_values",
         "app",
         "body",
         "conn_info",
@@ -146,7 +146,7 @@ class Request:
         self.head = head
 
         # enforce existing behavior prior to issue #2427
-        self.keep_blank_form_values = False
+        self.keep_blank_form_values: bool = False
 
         # Init but do not inhale
         self.body = b""
@@ -431,14 +431,6 @@ class Request:
         return self.parsed_credentials
 
     @property
-    def keep_blank_form_values(self) -> bool:
-        return self._keep_blank_form_values
-
-    @keep_blank_form_values.setter
-    def keep_blank_values(self, keep_blank_form_values: bool = False):
-        self._keep_blank_form_values = keep_blank_form_values
-
-    @property
     def form(self):
         if self.parsed_form is None:
             self.parsed_form = RequestParameters()
@@ -451,7 +443,8 @@ class Request:
                 if content_type == "application/x-www-form-urlencoded":
                     self.parsed_form = RequestParameters(
                         parse_qs(
-                            self.body.decode("utf-8"), self.keep_blank_form_values
+                            self.body.decode("utf-8"),
+                            self.keep_blank_form_values,
                         )
                     )
                 elif content_type == "multipart/form-data":

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -450,7 +450,7 @@ class Request:
             try:
                 if content_type == "application/x-www-form-urlencoded":
                     self.parsed_form = RequestParameters(
-                        parse_qs(self.body.decode("utf-8"), self._keep_blank_form_values)
+                        parse_qs(self.body.decode("utf-8"), self.keep_blank_values)
                     )
                 elif content_type == "multipart/form-data":
                     # TODO: Stream this instead of reading to/from memory

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1020,7 +1020,7 @@ async def test_post_form_urlencoded_asgi(app):
 def test_post_form_urlencoded_keep_blanks(app):
     @app.route("/", methods=["POST"])
     async def handler(request):
-        request.keep_blank_values = True
+        request.keep_blank_form_values = True
         return text("OK")
 
     payload = "test="
@@ -1038,7 +1038,7 @@ def test_post_form_urlencoded_keep_blanks(app):
 async def test_post_form_urlencoded_keep_blanks_asgi(app):
     @app.route("/", methods=["POST"])
     async def handler(request):
-        request.keep_blank_values = True
+        request.keep_blank_form_values = True
         return text("OK")
 
     payload = "test="

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1016,6 +1016,73 @@ async def test_post_form_urlencoded_asgi(app):
     assert request.form.get("test") == "OK"  # For request.parsed_form
 
 
+
+def test_post_form_urlencoded_keep_blanks(app):
+    @app.route("/", methods=["POST"])
+    async def handler(request):
+        request.keep_blank_values = True
+        return text("OK")
+
+    payload = "test="
+    headers = {"content-type": "application/x-www-form-urlencoded"}
+
+    request, response = app.test_client.post(
+        "/", data=payload, headers=headers
+    )
+
+    assert request.form(keep_blank_values=True).get("test") == ""
+    assert request.form.get("test") == ""  # For request.parsed_form
+
+
+@pytest.mark.asyncio
+async def test_post_form_urlencoded_keep_blanks_asgi(app):
+    @app.route("/", methods=["POST"])
+    async def handler(request):
+        request.keep_blank_values = True
+        return text("OK")
+
+    payload = "test="
+    headers = {"content-type": "application/x-www-form-urlencoded"}
+
+    request, response = await app.asgi_client.post(
+        "/", data=payload, headers=headers
+    )
+
+    assert request.form.get("test") == ""
+    assert request.form.get("test") == ""  # For request.parsed_form
+
+
+
+def test_post_form_urlencoded_drop_blanks(app):
+    @app.route("/", methods=["POST"])
+    async def handler(request):
+        return text("OK")
+
+    payload = "test="
+    headers = {"content-type": "application/x-www-form-urlencoded"}
+
+    request, response = app.test_client.post(
+        "/", data=payload, headers=headers
+    )
+
+    assert "test" not in request.form.keys()
+
+@pytest.mark.asyncio
+async def test_post_form_urlencoded_drop_blanks_asgi(app):
+    @app.route("/", methods=["POST"])
+    async def handler(request):
+        return text("OK")
+
+    payload = "test="
+    headers = {"content-type": "application/x-www-form-urlencoded"}
+
+    request, response = await app.asgi_client.post(
+        "/", data=payload, headers=headers
+    )
+
+    assert "test" not in request.form.keys()
+
+
 @pytest.mark.parametrize(
     "payload",
     [

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1030,7 +1030,7 @@ def test_post_form_urlencoded_keep_blanks(app):
         "/", data=payload, headers=headers
     )
 
-    assert request.form(keep_blank_values=True).get("test") == ""
+    assert request.form.get("test") == ""
     assert request.form.get("test") == ""  # For request.parsed_form
 
 


### PR DESCRIPTION
This is a non-breaking update to form parsing based on a realistic expectation of being able to preserve blank values that are passed. As this currently works, using the default behavior of urllib.parse_qs, blank values are dropped, however this is sometimes not the preferred behavior. urllib.parse_qs has a parameter (keep_blank_values) that defaults to false, but can be set to true to ensure this is available. This fix allows for that option to be used by creating a new request property that can be updated.

closes #2427 

- New request property: keep_blank_values (default false)
if set to true, will preserve blank values in x-www-form-urlencoded forms when request.form is accessed

- New tests:
form keep blanks
form drop blanks (expected behavior)
