### PR TITLE
Preserve blank form values for urlencoded forms (option)

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -426,7 +426,7 @@ class Request:
                 pass
         return self.parsed_credentials
 
-    def get_form(self, keep_blank_values: bool = False):
+    def get_form(self, keep_blank_values: bool = False) -> RequestParameters:
         self.parsed_form = RequestParameters()
         self.parsed_files = RequestParameters()
         content_type = self.headers.getone(
@@ -451,6 +451,8 @@ class Request:
                 )
         except Exception:
             error_logger.exception("Failed when parsing form")
+
+        return self.parsed_form
 
     @property
     def form(self):

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -153,7 +153,7 @@ class Request:
         self.parsed_credentials: Optional[Credentials] = None
         self.parsed_json = None
         self.parsed_form: Optional[RequestParameters] = None
-        self.parsed_files = None
+        self.parsed_files: Optional[RequestParameters] = None
         self.parsed_token: Optional[str] = None
         self.parsed_args: DefaultDict[
             Tuple[bool, bool, str, str], RequestParameters

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -443,7 +443,7 @@ class Request:
                 )
             elif content_type == "multipart/form-data":
                 # TODO: Stream this instead of reading to/from memory
-                boundary = parameters["boundary"].encode("utf-8")
+                boundary = parameters["boundary"].encode("utf-8")  # type: ignore
                 self.parsed_form, self.parsed_files = parse_multipart_form(
                     self.body, boundary
                 )

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -426,28 +426,34 @@ class Request:
                 pass
         return self.parsed_credentials
 
+    def get_form(self, keep_blank_values: bool = False):
+        self.parsed_form = RequestParameters()
+        self.parsed_files = RequestParameters()
+        content_type = self.headers.getone(
+            "content-type", DEFAULT_HTTP_CONTENT_TYPE
+        )
+        content_type, parameters = parse_content_header(content_type)
+        try:
+            if content_type == "application/x-www-form-urlencoded":
+                self.parsed_form = RequestParameters(
+                    parse_qs(
+                        self.body.decode("utf-8"),
+                        keep_blank_values=keep_blank_values,
+                    )
+                )
+            elif content_type == "multipart/form-data":
+                # TODO: Stream this instead of reading to/from memory
+                boundary = parameters["boundary"].encode("utf-8")
+                self.parsed_form, self.parsed_files = parse_multipart_form(
+                    self.body, boundary
+                )
+        except Exception:
+            error_logger.exception("Failed when parsing form")
+
     @property
     def form(self):
         if self.parsed_form is None:
-            self.parsed_form = RequestParameters()
-            self.parsed_files = RequestParameters()
-            content_type = self.headers.getone(
-                "content-type", DEFAULT_HTTP_CONTENT_TYPE
-            )
-            content_type, parameters = parse_content_header(content_type)
-            try:
-                if content_type == "application/x-www-form-urlencoded":
-                    self.parsed_form = RequestParameters(
-                        parse_qs(self.body.decode("utf-8"))
-                    )
-                elif content_type == "multipart/form-data":
-                    # TODO: Stream this instead of reading to/from memory
-                    boundary = parameters["boundary"].encode("utf-8")
-                    self.parsed_form, self.parsed_files = parse_multipart_form(
-                        self.body, boundary
-                    )
-            except Exception:
-                error_logger.exception("Failed when parsing form")
+            self.get_form()
 
         return self.parsed_form
 

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -443,7 +443,7 @@ class Request:
                 )
             elif content_type == "multipart/form-data":
                 # TODO: Stream this instead of reading to/from memory
-                boundary = parameters["boundary"].encode(    # type: ignore
+                boundary = parameters["boundary"].encode(  # type: ignore
                     "utf-8"
                 )  # type: ignore
                 self.parsed_form, self.parsed_files = parse_multipart_form(

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -426,7 +426,9 @@ class Request:
                 pass
         return self.parsed_credentials
 
-    def get_form(self, keep_blank_values: bool = False) -> RequestParameters:
+    def get_form(
+        self, keep_blank_values: bool = False
+    ) -> Optional[RequestParameters]:
         self.parsed_form = RequestParameters()
         self.parsed_files = RequestParameters()
         content_type = self.headers.getone(

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -443,7 +443,9 @@ class Request:
                 )
             elif content_type == "multipart/form-data":
                 # TODO: Stream this instead of reading to/from memory
-                boundary = parameters["boundary"].encode("utf-8")  # type: ignore
+                boundary = parameters["boundary"].encode(
+                    "utf-8"
+                )  # type: ignore
                 self.parsed_form, self.parsed_files = parse_multipart_form(
                     self.body, boundary
                 )

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -152,7 +152,7 @@ class Request:
         self.parsed_accept: Optional[AcceptContainer] = None
         self.parsed_credentials: Optional[Credentials] = None
         self.parsed_json = None
-        self.parsed_form = None
+        self.parsed_form: Optional[RequestParameters] = None
         self.parsed_files = None
         self.parsed_token: Optional[str] = None
         self.parsed_args: DefaultDict[

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -443,7 +443,7 @@ class Request:
                 )
             elif content_type == "multipart/form-data":
                 # TODO: Stream this instead of reading to/from memory
-                boundary = parameters["boundary"].encode(
+                boundary = parameters["boundary"].encode(    # type: ignore
                     "utf-8"
                 )  # type: ignore
                 self.parsed_form, self.parsed_files = parse_multipart_form(

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1016,6 +1016,72 @@ async def test_post_form_urlencoded_asgi(app):
     assert request.form.get("test") == "OK"  # For request.parsed_form
 
 
+def test_post_form_urlencoded_keep_blanks(app):
+    @app.route("/", methods=["POST"])
+    async def handler(request):
+        request.get_form(keep_blank_values=True)
+        return text("OK")
+
+    payload = "test="
+    headers = {"content-type": "application/x-www-form-urlencoded"}
+
+    request, response = app.test_client.post(
+        "/", data=payload, headers=headers
+    )
+
+    assert request.form.get("test") == ""
+    assert request.form.get("test") == ""  # For request.parsed_form
+
+
+@pytest.mark.asyncio
+async def test_post_form_urlencoded_keep_blanks_asgi(app):
+    @app.route("/", methods=["POST"])
+    async def handler(request):
+        request.get_form(keep_blank_values=True)
+        return text("OK")
+
+    payload = "test="
+    headers = {"content-type": "application/x-www-form-urlencoded"}
+
+    request, response = await app.asgi_client.post(
+        "/", data=payload, headers=headers
+    )
+
+    assert request.form.get("test") == ""
+    assert request.form.get("test") == ""  # For request.parsed_form
+
+
+
+def test_post_form_urlencoded_drop_blanks(app):
+    @app.route("/", methods=["POST"])
+    async def handler(request):
+        return text("OK")
+
+    payload = "test="
+    headers = {"content-type": "application/x-www-form-urlencoded"}
+
+    request, response = app.test_client.post(
+        "/", data=payload, headers=headers
+    )
+
+    assert "test" not in request.form.keys()
+
+@pytest.mark.asyncio
+async def test_post_form_urlencoded_drop_blanks_asgi(app):
+    @app.route("/", methods=["POST"])
+    async def handler(request):
+        return text("OK")
+
+    payload = "test="
+    headers = {"content-type": "application/x-www-form-urlencoded"}
+
+    request, response = await app.asgi_client.post(
+        "/", data=payload, headers=headers
+    )
+
+    assert "test" not in request.form.keys()
+
+
 @pytest.mark.parametrize(
     "payload",
     [


### PR DESCRIPTION
This is a non-breaking update to form parsing based on a realistic expectation of being able to preserve blank values that are passed. As this currently works, using the default behavior of urllib.parse_qs, blank values are dropped, however this is sometimes not the preferred behavior. urllib.parse_qs has a parameter (keep_blank_values) that defaults to false, but can be set to true to ensure this is available. This fix allows for that option to be used by creating a new request property that can be updated.

closes #2427

refactor logic from the .form property to .get_form() method which will accept the optional parameter of keep_blank_values as a boolean. By default this is False, preserving the existing behavior. If set to True, will preserve blank values in x-www-form-urlencoded forms when request.form is accessed

New tests:
form keep blanks
form drop blanks (expected behavior)