### PR TITLE
2369 graceful shutdown of signal handlers

### DIFF
--- a/sanic/mixins/runner.py
+++ b/sanic/mixins/runner.py
@@ -367,6 +367,7 @@ class RunnerMixin(metaclass=SanicMeta):
         """
         if self.state.stage is not ServerStage.STOPPED:
             self.shutdown_tasks(timeout=0)
+            self.shutdown_signal_handlers()
             for task in all_tasks():
                 with suppress(AttributeError):
                     if task.get_name() == "RunServer":

--- a/sanic/signals.py
+++ b/sanic/signals.py
@@ -192,7 +192,7 @@ class SignalRouter(BaseRouter):
         if inline:
             return await dispatch
 
-        task = asyncio.get_running_loop().create_task(dispatch)
+        task = asyncio.get_running_loop().create_task(dispatch, name="signal")
         await asyncio.sleep(0)
         return task
 

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -402,3 +402,15 @@ def test_signal_reservation(app, event, expected):
             app.signal(event)(lambda: ...)
     else:
         app.signal(event)(lambda: ...)
+
+
+@pytest.mark.asyncio
+async def test_signal_handler_task_name(app):
+    @app.signal("foo.bar.baz")
+    def sync_signal(*_):
+        ...
+
+    app.signal_router.finalize()
+
+    signal_handler_task = await app.dispatch("foo.bar.baz")
+    assert signal_handler_task.get_name() == "signal"


### PR DESCRIPTION
Issue: https://github.com/sanic-org/sanic/issues/2369

This PR makes two key changes:

- It names signal handler `asyncio.Task`s "signal" so that they are distinguishable from other `asyncio.Task`s that are running in the event loop.
- It cancels running signal handler `asyncio.Task`s when sanic is stopped.