### PR TITLE
Move verbosity filtering to logger

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -1573,8 +1573,9 @@ class Sanic(BaseSanic, RunnerMixin, metaclass=TouchUpMeta):
             "shutdown",
         ):
             raise SanicException(f"Invalid server event: {event}")
-        if self.state.verbosity >= 1:
-            logger.debug(f"Triggering server events: {event}")
+        logger.debug(
+            f"Triggering server events: {event}", extra={"verbosity": 1}
+        )
         reverse = concern == "shutdown"
         if loop is None:
             loop = self.loop

--- a/sanic/application/state.py
+++ b/sanic/application/state.py
@@ -9,7 +9,7 @@ from socket import socket
 from ssl import SSLContext
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Union
 
-from sanic.log import logger
+from sanic.log import VerbosityFilter, logger
 from sanic.server.async_server import AsyncioServer
 
 
@@ -90,6 +90,9 @@ class ApplicationState:
             self.app.error_handler.debug = self.app.debug
         if getattr(self.app, "configure_logging", False) and self.app.debug:
             logger.setLevel(logging.DEBUG)
+
+    def set_verbosity(self, value: int):
+        VerbosityFilter.verbosity = value
 
     @property
     def is_debug(self):

--- a/sanic/asgi.py
+++ b/sanic/asgi.py
@@ -25,27 +25,28 @@ class Lifespan:
     def __init__(self, asgi_app: ASGIApp) -> None:
         self.asgi_app = asgi_app
 
-        if self.asgi_app.sanic_app.state.verbosity > 0:
-            if (
-                "server.init.before"
-                in self.asgi_app.sanic_app.signal_router.name_index
-            ):
-                logger.debug(
-                    'You have set a listener for "before_server_start" '
-                    "in ASGI mode. "
-                    "It will be executed as early as possible, but not before "
-                    "the ASGI server is started."
-                )
-            if (
-                "server.shutdown.after"
-                in self.asgi_app.sanic_app.signal_router.name_index
-            ):
-                logger.debug(
-                    'You have set a listener for "after_server_stop" '
-                    "in ASGI mode. "
-                    "It will be executed as late as possible, but not after "
-                    "the ASGI server is stopped."
-                )
+        if (
+            "server.init.before"
+            in self.asgi_app.sanic_app.signal_router.name_index
+        ):
+            logger.debug(
+                'You have set a listener for "before_server_start" '
+                "in ASGI mode. "
+                "It will be executed as early as possible, but not before "
+                "the ASGI server is started.",
+                extra={"verbosity": 1},
+            )
+        if (
+            "server.shutdown.after"
+            in self.asgi_app.sanic_app.signal_router.name_index
+        ):
+            logger.debug(
+                'You have set a listener for "after_server_stop" '
+                "in ASGI mode. "
+                "It will be executed as late as possible, but not after "
+                "the ASGI server is stopped.",
+                extra={"verbosity": 1},
+            )
 
     async def startup(self) -> None:
         """

--- a/sanic/log.py
+++ b/sanic/log.py
@@ -59,23 +59,37 @@ LOGGING_CONFIG_DEFAULTS: Dict[str, Any] = dict(  # no cov
 
 class Colors(str, Enum):  # no cov
     END = "\033[0m"
-    BLUE = "\033[01;34m"
+    RED = "\033[01;31m"
     GREEN = "\033[01;32m"
     YELLOW = "\033[01;33m"
-    RED = "\033[01;31m"
+    BLUE = "\033[01;34m"
+    PURPLE = "\033[01;35m"
 
+
+class VerbosityFilter(logging.Filter):
+    verbosity: int = 0
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        verbosity = getattr(record, "verbosity", 0)
+        return verbosity <= self.verbosity
+
+
+_verbosity_filter = VerbosityFilter()
 
 logger = logging.getLogger("sanic.root")  # no cov
+logger.addFilter(_verbosity_filter)
 """
 General Sanic logger
 """
 
 error_logger = logging.getLogger("sanic.error")  # no cov
+error_logger.addFilter(_verbosity_filter)
 """
 Logger used by Sanic for error logging
 """
 
 access_logger = logging.getLogger("sanic.access")  # no cov
+access_logger.addFilter(_verbosity_filter)
 """
 Logger used by Sanic for access logging
 """


### PR DESCRIPTION
We added `verbosity` as an option a couple releases ago. This was to help reduce some noise in the logging. It was cumbersome to implement, since you needed to read the value from the application state.

This PR makes the change to add it as an option to the record:

```python
logger.debug("Some message", extra={"verbosity": 2})
```