### PR TITLE
fixed manual to match current Sanic app name policy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,7 @@ Hello World Example
     from sanic import Sanic
     from sanic.response import json
 
-    app = Sanic("MyHelloWorldApp")
+    app = Sanic("my-hello-world-app")
 
     @app.route('/')
     async def test(request):

--- a/README.rst
+++ b/README.rst
@@ -114,7 +114,7 @@ Hello World Example
     from sanic import Sanic
     from sanic.response import json
 
-    app = Sanic("My Hello, world app")
+    app = Sanic("MyHelloWorldApp")
 
     @app.route('/')
     async def test(request):


### PR DESCRIPTION
Current app name in the manual (README) is wrong and cause an error due to Sanic app name policy 

according to the error that is being raised:
"Names must begin with a character and may only contain alphanumeric characters, _, or -"

Hence, it is suggested to change the name in the example to a valid name that contains only alphanumeric chars and hyphens