### PR TITLE
Properly catch websocket CancelledError in websocket handler in Python 3.7

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -992,10 +992,10 @@ class Sanic(BaseSanic, RunnerMixin, metaclass=TouchUpMeta):
         cancelled = False
         try:
             await fut
-        except Exception as e:
-            self.error_handler.log(request, e)
         except (CancelledError, ConnectionClosed):
             cancelled = True
+        except Exception as e:
+            self.error_handler.log(request, e)
         finally:
             self.websocket_tasks.remove(fut)
             if cancelled:


### PR DESCRIPTION
In python 3.8 `CancelledError` is subclass of `BaseException`, but in Python 3.7 and earlier, it is subclass of `Exception`. That means in python 3.7, the `CancelledError` gets caught by the general `Exception` handler, and does not correctly handle the case of a cancelled websocket task.

Fixes #2462