### PR TITLE
Properly catch websocket CancelledError in websocket handler in Python 3.7

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -1004,10 +1004,10 @@ class Sanic(BaseSanic, metaclass=TouchUpMeta):
         cancelled = False
         try:
             await fut
-        except Exception as e:
-            self.error_handler.log(request, e)
         except (CancelledError, ConnectionClosed):
             cancelled = True
+        except Exception as e:
+            self.error_handler.log(request, e)
         finally:
             self.websocket_tasks.remove(fut)
             if cancelled:


### PR DESCRIPTION
Apply fix #2463 to Sanic 21.12LTS version