### PR TITLE
Fix `test_cli` and `test_cookies`

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ import json
 import subprocess
 
 from pathlib import Path
+from typing import List
 
 import pytest
 
@@ -25,14 +26,14 @@ def capture(command):
     return out, err, proc.returncode
 
 
-def starting_line(lines):
+def starting_line(lines: List[str]):
     for idx, line in enumerate(lines):
         if line.strip().startswith(b"Sanic v"):
             return idx
     return 0
 
 
-def read_app_info(lines):
+def read_app_info(lines: List[str]):
     for line in lines:
         if line.startswith(b"{") and line.endswith(b"}"):
             return json.loads(line)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@ import json
 import subprocess
 
 from pathlib import Path
-from typing import List
+from typing import List, Optional, Tuple
 
 import pytest
 
@@ -11,7 +11,7 @@ from sanic_routing import __version__ as __routing_version__
 from sanic import __version__
 
 
-def capture(command):
+def capture(command: List[str]):
     proc = subprocess.Popen(
         command,
         stdout=subprocess.PIPE,
@@ -47,7 +47,7 @@ def read_app_info(lines: List[str]):
         ("fake.server.create_app()", None),
     ),
 )
-def test_server_run(appname, extra):
+def test_server_run(appname: str, extra: Optional[str]):
     command = ["sanic", appname]
     if extra:
         command.append(extra)
@@ -120,7 +120,7 @@ def test_error_with_path_as_instance_without_simple_arg():
         ),
     ),
 )
-def test_tls_options(cmd):
+def test_tls_options(cmd: Tuple[str]):
     command = ["sanic", "fake.server.app", *cmd, "-p=9999", "--debug"]
     out, err, exitcode = capture(command)
     assert exitcode != 1
@@ -141,7 +141,7 @@ def test_tls_options(cmd):
         ("--tls-strict-host",),
     ),
 )
-def test_tls_wrong_options(cmd):
+def test_tls_wrong_options(cmd: Tuple[str]):
     command = ["sanic", "fake.server.app", *cmd, "-p=9999", "--debug"]
     out, err, exitcode = capture(command)
     assert exitcode == 1
@@ -159,7 +159,7 @@ def test_tls_wrong_options(cmd):
         ("-H", "localhost", "-p", "9999"),
     ),
 )
-def test_host_port_localhost(cmd):
+def test_host_port_localhost(cmd: Tuple[str]):
     command = ["sanic", "fake.server.app", *cmd]
     out, err, exitcode = capture(command)
     lines = out.split(b"\n")
@@ -176,7 +176,7 @@ def test_host_port_localhost(cmd):
         ("-H", "127.0.0.127", "-p", "9999"),
     ),
 )
-def test_host_port_ipv4(cmd):
+def test_host_port_ipv4(cmd: Tuple[str]):
     command = ["sanic", "fake.server.app", *cmd]
     out, err, exitcode = capture(command)
     lines = out.split(b"\n")
@@ -193,7 +193,7 @@ def test_host_port_ipv4(cmd):
         ("-H", "::", "-p", "9999"),
     ),
 )
-def test_host_port_ipv6_any(cmd):
+def test_host_port_ipv6_any(cmd: Tuple[str]):
     command = ["sanic", "fake.server.app", *cmd]
     out, err, exitcode = capture(command)
     lines = out.split(b"\n")
@@ -210,7 +210,7 @@ def test_host_port_ipv6_any(cmd):
         ("-H", "::1", "-p", "9999"),
     ),
 )
-def test_host_port_ipv6_loopback(cmd):
+def test_host_port_ipv6_loopback(cmd: Tuple[str]):
     command = ["sanic", "fake.server.app", *cmd]
     out, err, exitcode = capture(command)
     lines = out.split(b"\n")
@@ -231,7 +231,7 @@ def test_host_port_ipv6_loopback(cmd):
         (4, ("-w", "4")),
     ),
 )
-def test_num_workers(num, cmd):
+def test_num_workers(num: int, cmd: Tuple[str]):
     command = ["sanic", "fake.server.app", *cmd]
     out, err, exitcode = capture(command)
     lines = out.split(b"\n")
@@ -246,7 +246,7 @@ def test_num_workers(num, cmd):
 
 
 @pytest.mark.parametrize("cmd", ("--debug",))
-def test_debug(cmd):
+def test_debug(cmd: str):
     command = ["sanic", "fake.server.app", cmd]
     out, err, exitcode = capture(command)
     lines = out.split(b"\n")
@@ -260,7 +260,7 @@ def test_debug(cmd):
 
 
 @pytest.mark.parametrize("cmd", ("--dev", "-d"))
-def test_dev(cmd):
+def test_dev(cmd: str):
     command = ["sanic", "fake.server.app", cmd]
     out, err, exitcode = capture(command)
     lines = out.split(b"\n")
@@ -273,7 +273,7 @@ def test_dev(cmd):
 
 
 @pytest.mark.parametrize("cmd", ("--auto-reload", "-r"))
-def test_auto_reload(cmd):
+def test_auto_reload(cmd: str):
     command = ["sanic", "fake.server.app", cmd]
     out, err, exitcode = capture(command)
     lines = out.split(b"\n")
@@ -289,7 +289,7 @@ def test_auto_reload(cmd):
 @pytest.mark.parametrize(
     "cmd,expected", (("--access-log", True), ("--no-access-log", False))
 )
-def test_access_logs(cmd, expected):
+def test_access_logs(cmd: str, expected: bool):
     command = ["sanic", "fake.server.app", cmd]
     out, err, exitcode = capture(command)
     lines = out.split(b"\n")
@@ -301,7 +301,7 @@ def test_access_logs(cmd, expected):
 
 
 @pytest.mark.parametrize("cmd", ("--version", "-v"))
-def test_version(cmd):
+def test_version(cmd: str):
     command = ["sanic", cmd]
     out, err, exitcode = capture(command)
     version_string = f"Sanic {__version__}; Routing {__routing_version__}\n"
@@ -316,7 +316,7 @@ def test_version(cmd):
         ("--no-noisy-exceptions", False),
     ),
 )
-def test_noisy_exceptions(cmd, expected):
+def test_noisy_exceptions(cmd: str, expected: bool):
     command = ["sanic", "fake.server.app", cmd]
     out, err, exitcode = capture(command)
     lines = out.split(b"\n")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,7 +18,7 @@ def capture(command):
         cwd=Path(__file__).parent,
     )
     try:
-        out, err = proc.communicate(timeout=1)
+        out, err = proc.communicate(timeout=10)
     except subprocess.TimeoutExpired:
         proc.kill()
         out, err = proc.communicate()

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -234,13 +234,11 @@ def test_cookie_expires(app: Sanic, expires: datetime):
         response = text("pass")
         response.cookies["test"] = "pass"
         response.cookies["test"]["expires"] = expires
-        print(response.cookies)
         return response
 
     request, response = app.test_client.get(
         "/", cookies=cookies, raw_cookies=True
     )
-    print(response.raw_cookies)
 
     cookie_expires = datetime.utcfromtimestamp(
         response.raw_cookies["test"].expires

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -223,17 +223,17 @@ def test_cookie_bad_max_age(app, max_age):
 
 
 @pytest.mark.parametrize(
-    "expires", [datetime.utcnow() + timedelta(seconds=60)]
+    "expires", [timedelta(seconds=60)]
 )
-def test_cookie_expires(app: Sanic, expires: datetime):
-    expires = expires.replace(microsecond=0)
+def test_cookie_expires(app: Sanic, expires: timedelta):
+    expires_time = datetime.utcnow().replace(microsecond=0) + expires
     cookies = {"test": "wait"}
 
     @app.get("/")
     def handler(request):
         response = text("pass")
         response.cookies["test"] = "pass"
-        response.cookies["test"]["expires"] = expires
+        response.cookies["test"]["expires"] = expires_time
         return response
 
     request, response = app.test_client.get(
@@ -246,7 +246,7 @@ def test_cookie_expires(app: Sanic, expires: datetime):
 
     assert response.status == 200
     assert response.cookies["test"] == "pass"
-    assert cookie_expires == expires
+    assert cookie_expires == expires_time
 
 
 @pytest.mark.parametrize("expires", ["Fri, 21-Dec-2018 15:30:00 GMT"])

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -222,9 +222,7 @@ def test_cookie_bad_max_age(app, max_age):
     assert response.status == 500
 
 
-@pytest.mark.parametrize(
-    "expires", [timedelta(seconds=60)]
-)
+@pytest.mark.parametrize("expires", [timedelta(seconds=60)])
 def test_cookie_expires(app: Sanic, expires: timedelta):
     expires_time = datetime.utcnow().replace(microsecond=0) + expires
     cookies = {"test": "wait"}

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -3,6 +3,7 @@ from http.cookies import SimpleCookie
 
 import pytest
 
+from sanic import Sanic
 from sanic.cookies import Cookie
 from sanic.response import text
 
@@ -224,7 +225,7 @@ def test_cookie_bad_max_age(app, max_age):
 @pytest.mark.parametrize(
     "expires", [datetime.utcnow() + timedelta(seconds=60)]
 )
-def test_cookie_expires(app, expires):
+def test_cookie_expires(app: Sanic, expires: datetime):
     expires = expires.replace(microsecond=0)
     cookies = {"test": "wait"}
 
@@ -238,6 +239,8 @@ def test_cookie_expires(app, expires):
     request, response = app.test_client.get(
         "/", cookies=cookies, raw_cookies=True
     )
+    print(response.raw_cookies)
+
     cookie_expires = datetime.utcfromtimestamp(
         response.raw_cookies["test"].expires
     ).replace(microsecond=0)

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -234,6 +234,7 @@ def test_cookie_expires(app: Sanic, expires: datetime):
         response = text("pass")
         response.cookies["test"] = "pass"
         response.cookies["test"]["expires"] = expires
+        print(response.cookies)
         return response
 
     request, response = app.test_client.get(


### PR DESCRIPTION
I was able to reproduce the test cli issues on my laptop, which is the timeout occurred when running the subprocess in `capture` function. After increasing the timeout locally, the issue never came up again during multiple tests.

Open this PR to further test the test cases.

I think this issue usually happen on smaller machine with lower performance.