### PR TITLE
Fix and improve file cache control header calculation

### DIFF
--- a/sanic/compat.py
+++ b/sanic/compat.py
@@ -51,7 +51,7 @@ use_trio = sys.argv[0].endswith("hypercorn") and "trio" in sys.argv
 if use_trio:  # pragma: no cover
     import trio  # type: ignore
 
-    def stat_async(path):
+    def stat_async(path) -> os.stat_result:
         return trio.Path(path).stat()
 
     open_async = trio.open_file

--- a/sanic/compat.py
+++ b/sanic/compat.py
@@ -3,6 +3,8 @@ import os
 import signal
 import sys
 
+from typing import Awaitable
+
 from multidict import CIMultiDict  # type: ignore
 
 
@@ -51,7 +53,7 @@ use_trio = sys.argv[0].endswith("hypercorn") and "trio" in sys.argv
 if use_trio:  # pragma: no cover
     import trio  # type: ignore
 
-    def stat_async(path) -> os.stat_result:
+    def stat_async(path) -> Awaitable[os.stat_result]:
         return trio.Path(path).stat()
 
     open_async = trio.open_file

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -5,7 +5,7 @@ from email.utils import formatdate
 from functools import partial
 from mimetypes import guess_type
 from os import path
-from pathlib import Path, PurePath
+from pathlib import PurePath
 from time import time
 from typing import (
     TYPE_CHECKING,

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -342,7 +342,8 @@ async def file(
     if isinstance(last_modified, datetime):
         last_modified = last_modified.replace(microsecond=0).timestamp()
     elif isinstance(last_modified, Default):
-        last_modified = (await stat_async(location)).st_mtime
+        stat = await stat_async(location)
+        last_modified = stat.st_mtime
 
     if last_modified:
         headers.setdefault(

--- a/sanic/response.py
+++ b/sanic/response.py
@@ -22,7 +22,7 @@ from typing import (
 )
 from urllib.parse import quote_plus
 
-from sanic.compat import Header, open_async
+from sanic.compat import Header, open_async, stat_async
 from sanic.constants import DEFAULT_HTTP_CONTENT_TYPE
 from sanic.cookies import CookieJar
 from sanic.exceptions import SanicException, ServerError
@@ -340,9 +340,9 @@ async def file(
         )
 
     if isinstance(last_modified, datetime):
-        last_modified = last_modified.timestamp()
+        last_modified = last_modified.replace(microsecond=0).timestamp()
     elif isinstance(last_modified, Default):
-        last_modified = Path(location).stat().st_mtime
+        last_modified = (await stat_async(location)).st_mtime
 
     if last_modified:
         headers.setdefault(


### PR DESCRIPTION
1. Microseconds in `datetime` should be removed for HTTP protocol.
2. Get `last_modified` from async file operation instead of the non-async `pathlib` function.