### PR TITLE
Respect error_format defined in app.config when None is given to app.route

### DIFF
--- a/sanic/mixins/routes.py
+++ b/sanic/mixins/routes.py
@@ -167,7 +167,7 @@ class RouteMixin(metaclass=SanicMeta):
                 # subprotocol is unordered, keep it unordered
                 subprotocols = frozenset(subprotocols)
 
-            if not error_format or error_format == "auto":
+            if error_format == "auto":
                 error_format = self._determine_error_format(handler)
 
             route = FutureRoute(


### PR DESCRIPTION
If `None` is given on `@app.route`, it should respect the global setting instead of go to "auto" check directly.