### PR TITLE
docs: Fix a few typos

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -999,7 +999,7 @@ class Sanic(BaseSanic, RunnerMixin, metaclass=TouchUpMeta):
     def asgi_client(self):  # noqa
         """
         A testing client that uses ASGI to reach into the application to
-        execute hanlers.
+        execute handlers.
 
         :return: testing client
         :rtype: :class:`SanicASGITestClient`
@@ -1194,7 +1194,7 @@ class Sanic(BaseSanic, RunnerMixin, metaclass=TouchUpMeta):
         `See user guide re: background tasks
         <https://sanicframework.org/guide/basics/tasks.html#background-tasks>`__
 
-        :param task: future, couroutine or awaitable
+        :param task: future, coroutine or awaitable
         """
         try:
             loop = self.loop  # Will raise SanicError if loop is not started

--- a/sanic/http/http3.py
+++ b/sanic/http/http3.py
@@ -378,7 +378,7 @@ def get_config(
     app: Sanic, ssl: Union[SanicSSLContext, CertSelector, SSLContext]
 ):
     # TODO:
-    # - proper selection needed if servince with multiple certs insted of
+    # - proper selection needed if service with multiple certs insted of
     #   just taking the first
     if isinstance(ssl, CertSelector):
         ssl = cast(SanicSSLContext, ssl.sanic_select[0])

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -188,7 +188,7 @@ class Request:
     @classmethod
     def get_current(cls) -> Request:
         """
-        Retrieve the currrent request object
+        Retrieve the current request object
 
         This implements `Context Variables
         <https://docs.python.org/3/library/contextvars.html>`_

--- a/sanic/server/websockets/impl.py
+++ b/sanic/server/websockets/impl.py
@@ -252,7 +252,7 @@ class WebsocketImplProtocol:
 
     def _force_disconnect(self) -> bool:
         """
-        Internal methdod used by end_connection and fail_connection
+        Internal method used by end_connection and fail_connection
         only when the graceful auto-closer cannot be used
         """
         if self.auto_closer_task and not self.auto_closer_task.done():


### PR DESCRIPTION
There are small typos in:
- sanic/app.py
- sanic/http/http3.py
- sanic/request.py
- sanic/server/websockets/impl.py

Fixes:
- Should read `service` rather than `servince`.
- Should read `method` rather than `methdod`.
- Should read `handlers` rather than `hanlers`.
- Should read `current` rather than `currrent`.
- Should read `coroutine` rather than `couroutine`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md