### PR TITLE
Additional logger and support for multiprocess manager

### DIFF
--- a/sanic/log.py
+++ b/sanic/log.py
@@ -25,6 +25,12 @@ LOGGING_CONFIG_DEFAULTS: Dict[str, Any] = dict(  # no cov
             "propagate": True,
             "qualname": "sanic.access",
         },
+        "sanic.server": {
+            "level": "INFO",
+            "handlers": ["console"],
+            "propagate": True,
+            "qualname": "sanic.server",
+        },
     },
     handlers={
         "console": {
@@ -100,6 +106,12 @@ access_logger = logging.getLogger("sanic.access")  # no cov
 Logger used by Sanic for access logging
 """
 access_logger.addFilter(_verbosity_filter)
+
+server_logger = logging.getLogger("sanic.server")  # no cov
+"""
+Logger used by Sanic for server related messages
+"""
+logger.addFilter(_verbosity_filter)
 
 
 def deprecation(message: str, version: float):  # no cov

--- a/sanic/mixins/startup.py
+++ b/sanic/mixins/startup.py
@@ -35,6 +35,7 @@ from typing import (
     cast,
 )
 
+from sanic.application.ext import setup_ext
 from sanic.application.logo import get_logo
 from sanic.application.motd import MOTD
 from sanic.application.state import ApplicationServerInfo, Mode, ServerStage
@@ -746,9 +747,12 @@ class StartupMixin(metaclass=SanicMeta):
 
         socks = []
         sync_manager = Manager()
+        setup_ext(primary)
         try:
-            main_start = primary_server_info.settings.pop("main_start", None)
-            main_stop = primary_server_info.settings.pop("main_stop", None)
+            primary_server_info.settings.pop("main_start", None)
+            primary_server_info.settings.pop("main_stop", None)
+            main_start = primary.listeners.get("main_process_start")
+            main_stop = primary.listeners.get("main_process_stop")
             app = primary_server_info.settings.pop("app")
             app.setup_loop()
             loop = new_event_loop()

--- a/sanic/server/runners.py
+++ b/sanic/server/runners.py
@@ -27,7 +27,7 @@ from signal import signal as signal_func
 from sanic.application.ext import setup_ext
 from sanic.compat import OS_IS_WINDOWS, ctrlc_workaround_for_windows
 from sanic.http.http3 import SessionTicketStore, get_config
-from sanic.log import error_logger, logger
+from sanic.log import error_logger, server_logger
 from sanic.models.server_types import Signal
 from sanic.server.async_server import AsyncioServer
 from sanic.server.protocols.http_protocol import Http3Protocol, HttpProtocol
@@ -149,12 +149,12 @@ def _setup_system_signals(
 def _run_server_forever(loop, before_stop, after_stop, cleanup, unix):
     pid = os.getpid()
     try:
-        logger.info("Starting worker [%s]", pid)
+        server_logger.info("Starting worker [%s]", pid)
         loop.run_forever()
     except KeyboardInterrupt:
         pass
     finally:
-        logger.info("Stopping worker [%s]", pid)
+        server_logger.info("Stopping worker [%s]", pid)
 
         loop.run_until_complete(before_stop())
 
@@ -372,7 +372,9 @@ def serve_multiple(server_settings, workers):
     processes = []
 
     def sig_handler(signal, frame):
-        logger.info("Received signal %s. Shutting down.", Signals(signal).name)
+        server_logger.info(
+            "Received signal %s. Shutting down.", Signals(signal).name
+        )
         for process in processes:
             os.kill(process.pid, SIGTERM)
 

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -503,9 +503,10 @@ def test_stack_trace_on_not_found(app, static_file_directory, caplog):
     counter = Counter([(r[0], r[1]) for r in caplog.record_tuples])
 
     assert response.status == 404
-    assert counter[("sanic.root", logging.INFO)] == 11
+    assert counter[("sanic.root", logging.INFO)] == 9
     assert counter[("sanic.root", logging.ERROR)] == 0
     assert counter[("sanic.error", logging.ERROR)] == 0
+    assert counter[("sanic.server", logging.INFO)] == 2
 
 
 def test_no_stack_trace_on_not_found(app, static_file_directory, caplog):
@@ -521,9 +522,10 @@ def test_no_stack_trace_on_not_found(app, static_file_directory, caplog):
     counter = Counter([(r[0], r[1]) for r in caplog.record_tuples])
 
     assert response.status == 404
-    assert counter[("sanic.root", logging.INFO)] == 11
+    assert counter[("sanic.root", logging.INFO)] == 9
     assert counter[("sanic.root", logging.ERROR)] == 0
     assert counter[("sanic.error", logging.ERROR)] == 0
+    assert counter[("sanic.server", logging.INFO)] == 2
     assert response.text == "No file: /static/non_existing_file.file"
 
 


### PR DESCRIPTION
A couple small changes relating to working with the new manager.

1. The startup and shutdown logs are on their own logger now
2. Run `setup_ext` so extensions can touch the main process instance
3. Make sure to get the full listener mapping for main process