### PR TITLE
Sleep in Reloader loop to conserve CPU resources

### DIFF
--- a/sanic/cli/app.py
+++ b/sanic/cli/app.py
@@ -181,6 +181,7 @@ Or, a path to a directory to run as a simple HTTP server:
 
         kwargs = {
             "access_log": self.args.access_log,
+            "auto_reload_interval": self.args.auto_reload_interval,
             "coffee": self.args.coffee,
             "debug": self.args.debug,
             "fast": self.args.fast,

--- a/sanic/cli/arguments.py
+++ b/sanic/cli/arguments.py
@@ -282,7 +282,6 @@ class DevelopmentGroup(Group):
             "--interval",
             "--auto-reload-interval",
             dest="auto_reload_interval",
-            default=1.0,
             type=float,
             help="Interval in seconds to check for file changes [default 1.0]",
         )

--- a/sanic/cli/arguments.py
+++ b/sanic/cli/arguments.py
@@ -278,6 +278,15 @@ class DevelopmentGroup(Group):
             ),
         )
         self.container.add_argument(
+            "-i",
+            "--interval",
+            "--auto-reload-interval",
+            dest="auto_reload_interval",
+            default=1.0,
+            type=float,
+            help="Interval in seconds to check for file changes [default 1.0]",
+        )
+        self.container.add_argument(
             "-R",
             "--reload-dir",
             dest="path",

--- a/sanic/config.py
+++ b/sanic/config.py
@@ -38,6 +38,7 @@ DEFAULT_CONFIG = {
     "ACCESS_LOG": False,
     "AUTO_EXTEND": True,
     "AUTO_RELOAD": False,
+    "AUTO_RELOAD_INTERVAL": 1.0,
     "EVENT_AUTOREGISTER": False,
     "DEPRECATION_FILTER": "once",
     "FORWARDED_FOR_HEADER": "X-Forwarded-For",
@@ -85,6 +86,7 @@ class Config(dict, metaclass=DescriptorMeta):
     ACCESS_LOG: bool
     AUTO_EXTEND: bool
     AUTO_RELOAD: bool
+    AUTO_RELOAD_INTERVAL: Union[int, float]
     EVENT_AUTOREGISTER: bool
     DEPRECATION_FILTER: FilterWarningType
     FORWARDED_FOR_HEADER: str

--- a/sanic/mixins/startup.py
+++ b/sanic/mixins/startup.py
@@ -817,7 +817,7 @@ class StartupMixin(metaclass=SanicMeta):
                 reload_dirs: Set[Path] = primary.state.reload_dirs.union(
                     *(app.state.reload_dirs for app in apps)
                 )
-                reloader = Reloader(monitor_pub, 1.0, reload_dirs, app_loader)
+                reloader = Reloader(monitor_pub, primary.config.AUTO_RELOAD_INTERVAL, reload_dirs, app_loader)
                 manager.manage("Reloader", reloader, {}, transient=False)
 
             inspector = None

--- a/sanic/mixins/startup.py
+++ b/sanic/mixins/startup.py
@@ -114,6 +114,7 @@ class StartupMixin(metaclass=SanicMeta):
         dev: bool = False,
         debug: bool = False,
         auto_reload: Optional[bool] = None,
+        auto_reload_interval: Optional[Union[int, float]] = None,
         version: HTTPVersion = HTTP.VERSION_1,
         ssl: Union[None, SSLContext, dict, str, list, tuple] = None,
         sock: Optional[socket] = None,
@@ -176,6 +177,7 @@ class StartupMixin(metaclass=SanicMeta):
             dev=dev,
             debug=debug,
             auto_reload=auto_reload,
+            auto_reload_interval=auto_reload_interval,
             version=version,
             ssl=ssl,
             sock=sock,
@@ -213,6 +215,7 @@ class StartupMixin(metaclass=SanicMeta):
         dev: bool = False,
         debug: bool = False,
         auto_reload: Optional[bool] = None,
+        auto_reload_interval: Optional[Union[int, float]] = None,
         version: HTTPVersion = HTTP.VERSION_1,
         ssl: Union[None, SSLContext, dict, str, list, tuple] = None,
         sock: Optional[socket] = None,
@@ -301,10 +304,12 @@ class StartupMixin(metaclass=SanicMeta):
                 WebSocketProtocol if self.websocket_enabled else HttpProtocol
             )
 
+
         # Set explicitly passed configuration values
         for attribute, value in {
             "ACCESS_LOG": access_log,
             "AUTO_RELOAD": auto_reload,
+            "AUTO_RELOAD_INTERVAL": auto_reload_interval,
             "MOTD": motd,
             "NOISY_EXCEPTIONS": noisy_exceptions,
         }.items():

--- a/sanic/mixins/startup.py
+++ b/sanic/mixins/startup.py
@@ -304,7 +304,6 @@ class StartupMixin(metaclass=SanicMeta):
                 WebSocketProtocol if self.websocket_enabled else HttpProtocol
             )
 
-
         # Set explicitly passed configuration values
         for attribute, value in {
             "ACCESS_LOG": access_log,
@@ -822,7 +821,12 @@ class StartupMixin(metaclass=SanicMeta):
                 reload_dirs: Set[Path] = primary.state.reload_dirs.union(
                     *(app.state.reload_dirs for app in apps)
                 )
-                reloader = Reloader(monitor_pub, primary.config.AUTO_RELOAD_INTERVAL, reload_dirs, app_loader)
+                reloader = Reloader(
+                    monitor_pub,
+                    primary.config.AUTO_RELOAD_INTERVAL,
+                    reload_dirs,
+                    app_loader,
+                )
                 manager.manage("Reloader", reloader, {}, transient=False)
 
             inspector = None

--- a/sanic/mixins/startup.py
+++ b/sanic/mixins/startup.py
@@ -612,6 +612,12 @@ class StartupMixin(metaclass=SanicMeta):
         extra = {}
         if self.config.AUTO_RELOAD:
             reload_display = "enabled"
+
+            if self.config.AUTO_RELOAD_INTERVAL:
+                reload_display += " [{:.1f}s]".format(
+                    self.config.AUTO_RELOAD_INTERVAL
+                )
+
             if self.state.reload_dirs:
                 reload_display += ", ".join(
                     [
@@ -622,6 +628,7 @@ class StartupMixin(metaclass=SanicMeta):
                         ),
                     ]
                 )
+
             display["auto-reload"] = reload_display
 
         packages = []

--- a/sanic/worker/reloader.py
+++ b/sanic/worker/reloader.py
@@ -9,6 +9,7 @@ from multiprocessing.connection import Connection
 from pathlib import Path
 from signal import SIGINT, SIGTERM
 from signal import signal as signal_func
+from time import sleep
 from typing import Dict, Set
 
 from sanic.server.events import trigger_events
@@ -62,6 +63,7 @@ class Reloader:
                 self.reload(",".join(changed) if changed else "unknown")
                 if after_trigger:
                     trigger_events(after_trigger, loop, app)
+            sleep(self.interval)
         else:
             if reloader_stop:
                 trigger_events(reloader_stop, loop, app)

--- a/sanic/worker/reloader.py
+++ b/sanic/worker/reloader.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from signal import SIGINT, SIGTERM
 from signal import signal as signal_func
 from time import sleep
-from typing import Dict, Set
+from typing import Dict, Set, Union
 
 from sanic.server.events import trigger_events
 from sanic.worker.loader import AppLoader
@@ -20,12 +20,12 @@ class Reloader:
     def __init__(
         self,
         publisher: Connection,
-        interval: float,
+        interval: Union[int, float],
         reload_dirs: Set[Path],
         app_loader: AppLoader,
     ):
         self._publisher = publisher
-        self.interval = interval
+        self.interval = float(interval)
         self.reload_dirs = reload_dirs
         self.run = True
         self.app_loader = app_loader

--- a/tests/fake/server.py
+++ b/tests/fake/server.py
@@ -23,6 +23,7 @@ async def app_info_dump(app: Sanic, _):
     app_data = {
         "access_log": app.config.ACCESS_LOG,
         "auto_reload": app.auto_reload,
+        "auto_reload_interval": app.config.AUTO_RELOAD_INTERVAL,
         "debug": app.debug,
         "noisy_exceptions": app.config.NOISY_EXCEPTIONS,
     }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -246,6 +246,18 @@ def test_auto_reload(cmd: str, caplog):
 
 
 @pytest.mark.parametrize(
+    "cmd",
+    (("--auto-reload-interval=5.0",), ("--interval=5.0",), ("-i", "5.0")),
+)
+def test_auto_reload_interval(cmd: str, caplog):
+    command = ["fake.server.app", *cmd]
+    lines = capture(command, caplog)
+    info = read_app_info(lines)
+
+    assert info["auto_reload_interval"] == 5.0
+
+
+@pytest.mark.parametrize(
     "cmd,expected",
     (
         ("", False),

--- a/tests/test_motd.py
+++ b/tests/test_motd.py
@@ -79,5 +79,20 @@ def test_reload_dirs(app):
             reload_dir="./", auto_reload=True, motd_display={"foo": "bar"}
         )
     mock.assert_called()
-    assert mock.call_args.args[2]["auto-reload"] == f"enabled, {os.getcwd()}"
+    assert (
+        mock.call_args.args[2]["auto-reload"]
+        == f"enabled [1.0s], {os.getcwd()}"
+    )
     assert mock.call_args.args[3] == {"foo": "bar"}
+
+
+def test_reload_interval(app):
+    app.config.LOGO = None
+    app.config.MOTD = True
+    app.config.AUTO_RELOAD = True
+    app.config.AUTO_RELOAD_INTERVAL = 5.0
+
+    with patch.object(MOTD, "output") as mock:
+        app.prepare()
+    mock.assert_called()
+    assert mock.call_args.args[2]["auto-reload"] == "enabled [5.0s]"


### PR DESCRIPTION
Fixes #2566

The Reloader class already has an unused `interval` property, this pull request simply adds the missing sleep.