### PR TITLE
Corrected `Colors` enum under Python 3.11

### DIFF
--- a/sanic/log.py
+++ b/sanic/log.py
@@ -2,10 +2,21 @@ import logging
 import sys
 
 from enum import Enum
-from typing import Any, Dict
+from typing import TYPE_CHECKING, Any, Dict
 from warnings import warn
 
 from sanic.compat import is_atty
+
+
+# Python 3.11 changed the way Enum formatting works for mixed-in types.
+if sys.version_info < (3, 11, 0):
+
+    class StrEnum(str, Enum):
+        pass
+
+else:
+    if not TYPE_CHECKING:
+        from enum import StrEnum
 
 
 LOGGING_CONFIG_DEFAULTS: Dict[str, Any] = dict(  # no cov
@@ -68,7 +79,7 @@ Defult logging configuration
 """
 
 
-class Colors(str, Enum):  # no cov
+class Colors(StrEnum):  # no cov
     END = "\033[0m"
     BOLD = "\033[1m"
     BLUE = "\033[34m"

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -10,6 +10,7 @@ import pytest
 import sanic
 
 from sanic import Sanic
+from sanic.log import Colors
 from sanic.log import LOGGING_CONFIG_DEFAULTS, logger
 from sanic.response import text
 
@@ -250,3 +251,14 @@ def test_verbosity(app, caplog, app_verbosity, log_verbosity, exists):
 
     if app_verbosity == 0:
         assert ("sanic.root", logging.INFO, "DEFAULT") in caplog.record_tuples
+
+
+def test_colors_enum_format():
+    assert f'{Colors.END}' == Colors.END.value
+    assert f'{Colors.BOLD}' == Colors.BOLD.value
+    assert f'{Colors.BLUE}' == Colors.BLUE.value
+    assert f'{Colors.GREEN}' == Colors.GREEN.value
+    assert f'{Colors.PURPLE}' == Colors.PURPLE.value
+    assert f'{Colors.RED}' == Colors.RED.value
+    assert f'{Colors.SANIC}' == Colors.SANIC.value
+    assert f'{Colors.YELLOW}' == Colors.YELLOW.value


### PR DESCRIPTION
Python 3.11 have made some changes to how mixed-in Enum formatting works. From the changelog:

> Changed [`Enum.__format__()`](https://docs.python.org/3.11/library/enum.html#enum.Enum.__format__) (the default for [format()](https://docs.python.org/3.11/library/functions.html#format), [str.format()](https://docs.python.org/3.11/library/stdtypes.html#str.format) and [f-string](https://docs.python.org/3.11/glossary.html#term-f-string)s) of enums with mixed-in types (e.g. [int](https://docs.python.org/3.11/library/functions.html#int), [str](https://docs.python.org/3.11/library/stdtypes.html#str)) to also include the class name in the output, not just the member’s key. This matches the existing behavior of [`enum.Enum.__str__()`](https://docs.python.org/3.11/library/enum.html#enum.Enum.__str__), returning e.g. 'AnEnum.MEMBER' for an enum AnEnum(str, Enum) instead of just 'MEMBER'.

This PR fixes this issue by using the new `StrEnum` from Python 3.11 if available, substituting it for a subclass otherwise.

NOTE: I would recommend adding python 3.11 to unit tests before merging this one.

Fixes https://github.com/sanic-org/sanic/issues/2589