### PR TITLE
fix: sideeffects created by changing fork to spawn

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -61,7 +61,7 @@ from sanic.exceptions import (
     URLBuildError,
 )
 from sanic.handlers import ErrorHandler
-from sanic.helpers import _default
+from sanic.helpers import Default
 from sanic.http import Stage
 from sanic.log import (
     LOGGING_CONFIG_DEFAULTS,
@@ -1502,7 +1502,7 @@ class Sanic(BaseSanic, StartupMixin, metaclass=TouchUpMeta):
 
         if self.state.is_debug and self.config.TOUCHUP is not True:
             self.config.TOUCHUP = False
-        elif self.config.TOUCHUP is _default:
+        elif isinstance(self.config.TOUCHUP, Default):
             self.config.TOUCHUP = True
 
         # Setup routers

--- a/sanic/asgi.py
+++ b/sanic/asgi.py
@@ -7,7 +7,7 @@ from urllib.parse import quote
 
 from sanic.compat import Header
 from sanic.exceptions import ServerError
-from sanic.helpers import _default
+from sanic.helpers import Default
 from sanic.http import Stage
 from sanic.log import logger
 from sanic.models.asgi import ASGIReceive, ASGIScope, ASGISend, MockTransport
@@ -61,7 +61,7 @@ class Lifespan:
         await self.asgi_app.sanic_app._server_event("init", "before")
         await self.asgi_app.sanic_app._server_event("init", "after")
 
-        if self.asgi_app.sanic_app.config.USE_UVLOOP is not _default:
+        if not isinstance(self.asgi_app.sanic_app.config.USE_UVLOOP, Default):
             warnings.warn(
                 "You have set the USE_UVLOOP configuration option, but Sanic "
                 "cannot control the event loop when running in ASGI mode."

--- a/sanic/config.py
+++ b/sanic/config.py
@@ -199,7 +199,7 @@ class Config(dict, metaclass=DescriptorMeta):
 
     @property
     def FALLBACK_ERROR_FORMAT(self) -> str:
-        if self._FALLBACK_ERROR_FORMAT is _default:
+        if isinstance(self._FALLBACK_ERROR_FORMAT, Default):
             return DEFAULT_FORMAT
         return self._FALLBACK_ERROR_FORMAT
 
@@ -207,7 +207,7 @@ class Config(dict, metaclass=DescriptorMeta):
     def FALLBACK_ERROR_FORMAT(self, value):
         self._check_error_format(value)
         if (
-            self._FALLBACK_ERROR_FORMAT is not _default
+            not isinstance(self._FALLBACK_ERROR_FORMAT, Default)
             and value != self._FALLBACK_ERROR_FORMAT
         ):
             error_logger.warning(

--- a/sanic/mixins/startup.py
+++ b/sanic/mixins/startup.py
@@ -41,7 +41,7 @@ from sanic.application.motd import MOTD
 from sanic.application.state import ApplicationServerInfo, Mode, ServerStage
 from sanic.base.meta import SanicMeta
 from sanic.compat import OS_IS_WINDOWS, is_atty
-from sanic.helpers import _default
+from sanic.helpers import Default
 from sanic.http.constants import HTTP
 from sanic.http.tls import get_ssl_context, process_to_context
 from sanic.http.tls.context import SanicSSLContext
@@ -91,7 +91,8 @@ class StartupMixin(metaclass=SanicMeta):
     def setup_loop(self):
         if not self.asgi:
             if self.config.USE_UVLOOP is True or (
-                self.config.USE_UVLOOP is _default and not OS_IS_WINDOWS
+                isinstance(self.config.USE_UVLOOP, Default)
+                and not OS_IS_WINDOWS
             ):
                 try_use_uvloop()
             elif OS_IS_WINDOWS:
@@ -431,7 +432,7 @@ class StartupMixin(metaclass=SanicMeta):
             run_async=return_asyncio_server,
         )
 
-        if self.config.USE_UVLOOP is not _default:
+        if isinstance(self.config.USE_UVLOOP, Default):
             error_logger.warning(
                 "You are trying to change the uvloop configuration, but "
                 "this is only effective when using the run(...) method. "

--- a/sanic/mixins/startup.py
+++ b/sanic/mixins/startup.py
@@ -432,7 +432,7 @@ class StartupMixin(metaclass=SanicMeta):
             run_async=return_asyncio_server,
         )
 
-        if isinstance(self.config.USE_UVLOOP, Default):
+        if not isinstance(self.config.USE_UVLOOP, Default):
             error_logger.warning(
                 "You are trying to change the uvloop configuration, but "
                 "this is only effective when using the run(...) method. "

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -349,11 +349,11 @@ def test_get_app_does_not_exist():
     with pytest.raises(
         SanicException,
         match="Sanic app name 'does-not-exist' not found.\n"
-        "App instantiation must occur outside "
-        "if __name__ == '__main__' "
-        "block or by using an AppLoader.\nSee "
-        "https://sanic.dev/en/guide/deployment/app-loader.html"
-        " for more details.",
+            "App instantiation must occur outside "
+            "if __name__ == '__main__' "
+            "block or by using an AppLoader.\nSee "
+            "https://sanic.dev/en/guide/deployment/app-loader.html"
+            " for more details."
     ):
         Sanic.get_app("does-not-exist")
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -498,7 +498,7 @@ def test_uvloop_cannot_never_called_with_create_server(caplog, monkeypatch):
 
     counter = Counter([(r[1], r[2]) for r in caplog.record_tuples])
     modified = sum(
-        1 for app in apps if isinstance(app.config.USE_UVLOOP, Default)
+        1 for app in apps if not isinstance(app.config.USE_UVLOOP, Default)
     )
 
     assert counter[(logging.WARNING, message)] == modified

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -15,7 +15,7 @@ from sanic import Sanic
 from sanic.compat import OS_IS_WINDOWS
 from sanic.config import Config
 from sanic.exceptions import SanicException
-from sanic.helpers import _default
+from sanic.helpers import Default
 from sanic.log import LOGGING_CONFIG_DEFAULTS
 from sanic.response import text
 from sanic.router import Route
@@ -349,11 +349,11 @@ def test_get_app_does_not_exist():
     with pytest.raises(
         SanicException,
         match="Sanic app name 'does-not-exist' not found.\n"
-            "App instantiation must occur outside "
-            "if __name__ == '__main__' "
-            "block or by using an AppLoader.\nSee "
-            "https://sanic.dev/en/guide/deployment/app-loader.html"
-            " for more details."
+        "App instantiation must occur outside "
+        "if __name__ == '__main__' "
+        "block or by using an AppLoader.\nSee "
+        "https://sanic.dev/en/guide/deployment/app-loader.html"
+        " for more details.",
     ):
         Sanic.get_app("does-not-exist")
 
@@ -497,7 +497,9 @@ def test_uvloop_cannot_never_called_with_create_server(caplog, monkeypatch):
     )
 
     counter = Counter([(r[1], r[2]) for r in caplog.record_tuples])
-    modified = sum(1 for app in apps if app.config.USE_UVLOOP is not _default)
+    modified = sum(
+        1 for app in apps if isinstance(app.config.USE_UVLOOP, Default)
+    )
 
     assert counter[(logging.WARNING, message)] == modified
 


### PR DESCRIPTION
We discussed it on [Discord](https://discord.com/channels/812221182594121728/873112965707096074/1035187708227756194
).

This PR solves the problem that unintended behavior occurs when using the is keyword as the multiprocess start method is changed from spawn to fork.