### PR TITLE
Require uvloop >= 0.15.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ env_dependency = (
     '; sys_platform != "win32" ' 'and implementation_name == "cpython"'
 )
 ujson = "ujson>=1.35" + env_dependency
-uvloop = "uvloop>=0.5.3" + env_dependency
+uvloop = "uvloop>=0.15.0" + env_dependency
 types_ujson = "types-ujson" + env_dependency
 requirements = [
     "sanic-routing>=22.8.0",


### PR DESCRIPTION
An issue (https://github.com/sanic-org/sanic/issues/2496) reported by @ancalita claims Sanic requires uvloop >= 0.15.0

During testing, the CI results (https://github.com/sanic-org/sanic/pull/2597) show that Sanic is broken with uvloop version less than 0.15.0

So, let's update the dependency requirement in `setup.py` to fix the issue.

uvloop PR: https://github.com/MagicStack/uvloop/pull/334
