### PR TITLE
Add broadcast feature to websocket

### DIFF
--- a/sanic/server/protocols/base_protocol.py
+++ b/sanic/server/protocols/base_protocol.py
@@ -74,6 +74,13 @@ class SanicProtocol(asyncio.Protocol):
         self.transport.write(data)
         self._time = current_time()
 
+    def send_sync(self, data):
+        """
+        Generic data write implementation without backpressure control.
+        """
+        self.transport.write(data)
+        self._time = current_time()
+
     async def receive_more(self):
         """
         Wait until more data is received into the Server protocol's buffer

--- a/sanic/server/websockets/impl.py
+++ b/sanic/server/websockets/impl.py
@@ -727,6 +727,9 @@ class WebsocketImplProtocol:
             # Catch a common mistake -- passing a dict to send().
             raise TypeError("data is a dict-like object")
 
+        else:
+            raise TypeError("Websocket data must be bytes, str.")
+
         for websocket in websockets:
             if websocket.connection.state is not OPEN:
                 continue

--- a/sanic/server/websockets/impl.py
+++ b/sanic/server/websockets/impl.py
@@ -702,6 +702,20 @@ class WebsocketImplProtocol:
     def broadcast(
         websockets: "Iterable[WebsocketImplProtocol]", message: Data
     ) -> None:
+        """
+        Broadcast a message to several WebSocket connections.
+        A string (:class:`str`) is sent as a `Text frame`_. A bytestring or
+        bytes-like object (:class:`bytes`, :class:`bytearray`, or
+        :class:`memoryview`) is sent as a `Binary frame`_.
+        .. _Text frame: https://tools.ietf.org/html/rfc6455#section-5.6
+        .. _Binary frame: https://tools.ietf.org/html/rfc6455#section-5.6
+        :meth:`send` also accepts an iterable of strings, bytestrings, or
+        bytes-like objects.
+        :meth:`broadcast` rejects dict-like objects because this is often an error.
+        If you wish to send the keys of a dict-like object as fragments, call
+        its :meth:`~dict.keys` method and pass the result to :meth:`broadcast`.
+        :raises TypeError: for unsupported inputs
+        """
         if isinstance(message, str):
             op = Opcode.TEXT
             message = message.encode("utf-8")

--- a/sanic/server/websockets/impl.py
+++ b/sanic/server/websockets/impl.py
@@ -700,8 +700,7 @@ class WebsocketImplProtocol:
 
     @staticmethod
     def broadcast(
-        websockets: "Iterable[WebsocketImplProtocol]",
-        message: Union[Data, Iterable[Data]],
+        websockets: "Iterable[WebsocketImplProtocol]", message: Data
     ) -> None:
         if isinstance(message, str):
             op = Opcode.TEXT
@@ -713,12 +712,6 @@ class WebsocketImplProtocol:
         elif isinstance(message, Mapping):
             # Catch a common mistake -- passing a dict to send().
             raise TypeError("data is a dict-like object")
-
-        elif isinstance(message, Iterable):
-            # Fragmented message -- regular iterator.
-            raise NotImplementedError(
-                "Fragmented websocket messages are not supported."
-            )
 
         for websocket in websockets:
             if websocket.connection.state is not OPEN:

--- a/sanic/server/websockets/impl.py
+++ b/sanic/server/websockets/impl.py
@@ -711,7 +711,8 @@ class WebsocketImplProtocol:
         .. _Binary frame: https://tools.ietf.org/html/rfc6455#section-5.6
         :meth:`send` also accepts an iterable of strings, bytestrings, or
         bytes-like objects.
-        :meth:`broadcast` rejects dict-like objects because this is often an error.
+        :meth:`broadcast` rejects dict-like objects because this is often
+        an error.
         If you wish to send the keys of a dict-like object as fragments, call
         its :meth:`~dict.keys` method and pass the result to :meth:`broadcast`.
         :raises TypeError: for unsupported inputs

--- a/tests/test_ws_handlers.py
+++ b/tests/test_ws_handlers.py
@@ -54,3 +54,20 @@ def test_ws_handler_async_for(
     )
     assert ws_proxy.client_sent == ["test 1", "test 2", ""]
     assert ws_proxy.client_received == ["test 1", "test 2"]
+
+
+def test_ws_handler_broadcast(
+    app: Sanic,
+    simple_ws_mimic_client: MimicClientType,
+):
+    @app.websocket("/ws")
+    async def ws_echo_handler(request: Request, ws: Websocket):
+        while True:
+            msg = await ws.recv()
+            Websocket.broadcast([ws], msg)
+
+    _, ws_proxy = app.test_client.websocket(
+        "/ws", mimic=simple_ws_mimic_client
+    )
+    assert ws_proxy.client_sent == ["test 1", "test 2", ""]
+    assert ws_proxy.client_received == ["test 1", "test 2"]


### PR DESCRIPTION
Adds a `broadcast()` function like [websockets](https://websockets.readthedocs.io/en/stable/reference/utilities.html#websockets.broadcast) to WebsocketImplProtocol to broadcast a message to several websocket connections efficiently.
This pushes the message synchronously to all connections without backpressure.

example
```python
from sanic import Websocket

Websocket.boradcast(a_list_of_websocket_connections, a_message_to_send)
```

To implement this, `send_sync` method, data writer without backpressure control, is added to SanicProtocol.