### PR TITLE
Force socket shutdown before close

### DIFF
--- a/sanic/mixins/startup.py
+++ b/sanic/mixins/startup.py
@@ -19,7 +19,7 @@ from importlib import import_module
 from multiprocessing import Manager, Pipe, get_context
 from multiprocessing.context import BaseContext
 from pathlib import Path
-from socket import socket
+from socket import SHUT_RDWR, socket
 from ssl import SSLContext
 from typing import (
     TYPE_CHECKING,
@@ -864,6 +864,7 @@ class StartupMixin(metaclass=SanicMeta):
 
             sync_manager.shutdown()
             for sock in socks:
+                sock.shutdown(SHUT_RDWR)
                 sock.close()
             socks = []
             trigger_events(main_stop, loop, primary)


### PR DESCRIPTION
From a discussion on Discord, multi-process mode does not allow sockets to be rebound. Forcing socket shutdown from the main upon cleanup seems to solve this as shown here:

![image](https://user-images.githubusercontent.com/166269/204126432-5a7d0617-769f-4056-a73e-0da2e567ab74.png)
