### PR TITLE
Add compatibility with websockets 11.0.

### DIFF
--- a/sanic/server/protocols/websocket_protocol.py
+++ b/sanic/server/protocols/websocket_protocol.py
@@ -80,7 +80,7 @@ class WebSocketProtocol(HttpProtocol):
         # Called by Sanic Server when shutting down
         # If we've upgraded to websocket, shut it down
         if self.websocket is not None:
-            if self.websocket.connection.state in (CLOSING, CLOSED):
+            if self.websocket.ws_proto.state in (CLOSING, CLOSED):
                 return True
             elif self.websocket.loop is not None:
                 self.websocket.loop.create_task(self.websocket.close(1001))

--- a/sanic/server/protocols/websocket_protocol.py
+++ b/sanic/server/protocols/websocket_protocol.py
@@ -5,8 +5,8 @@ try:  # websockets < 11.0
     from websockets.connection import State
     from websockets.server import ServerConnection as ServerProtocol
 except ImportError:  # websockets >= 11.0
-    from websockets.protocol import State
-    from websockets.server import ServerProtocol
+    from websockets.protocol import State  # type: ignore
+    from websockets.server import ServerProtocol  # type: ignore
 
 from websockets.typing import Subprotocol
 

--- a/sanic/server/protocols/websocket_protocol.py
+++ b/sanic/server/protocols/websocket_protocol.py
@@ -2,10 +2,10 @@ from typing import TYPE_CHECKING, Optional, Sequence, cast
 
 
 try:  # websockets < 11.0
-    from websockets.connection import CLOSED, CLOSING, OPEN
+    from websockets.connection import State
     from websockets.server import ServerConnection as ServerProtocol
 except ImportError:  # websockets >= 11.0
-    from websockets.protocol import CLOSED, CLOSING, OPEN
+    from websockets.protocol import State
     from websockets.server import ServerProtocol
 
 from websockets.typing import Subprotocol
@@ -19,6 +19,11 @@ from ..websockets.impl import WebsocketImplProtocol
 
 if TYPE_CHECKING:
     from websockets import http11
+
+
+OPEN = State.OPEN
+CLOSING = State.CLOSING
+CLOSED = State.CLOSED
 
 
 class WebSocketProtocol(HttpProtocol):

--- a/sanic/server/websockets/impl.py
+++ b/sanic/server/websockets/impl.py
@@ -29,7 +29,7 @@ except ImportError:  # websockets >= 11.0
 
 from websockets.typing import Data
 
-from sanic.log import error_logger, logger
+from sanic.log import deprecation, error_logger, logger
 from sanic.server.protocols.base_protocol import SanicProtocol
 
 from ...exceptions import ServerError, WebsocketClosed
@@ -98,6 +98,15 @@ class WebsocketImplProtocol:
     @property
     def subprotocol(self):
         return self.ws_proto.subprotocol
+
+    @property
+    def connection(self):
+        deprecation(
+            "The connection property has been deprecated and will be removed. "
+            "Please use the ws_proto property instead going forward.",
+            22.6,
+        )
+        return self.ws_proto
 
     def pause_frames(self):
         if not self.can_pause:

--- a/sanic/server/websockets/impl.py
+++ b/sanic/server/websockets/impl.py
@@ -24,8 +24,8 @@ try:  # websockets < 11.0
     from websockets.connection import Event, State
     from websockets.server import ServerConnection as ServerProtocol
 except ImportError:  # websockets >= 11.0
-    from websockets.protocol import Event, State
-    from websockets.server import ServerProtocol
+    from websockets.protocol import Event, State  # type: ignore
+    from websockets.server import ServerProtocol  # type: ignore
 
 from websockets.typing import Data
 

--- a/sanic/server/websockets/impl.py
+++ b/sanic/server/websockets/impl.py
@@ -12,14 +12,21 @@ from typing import (
     Union,
 )
 
-from websockets.connection import CLOSED, CLOSING, OPEN, Event
 from websockets.exceptions import (
     ConnectionClosed,
     ConnectionClosedError,
     ConnectionClosedOK,
 )
 from websockets.frames import Frame, Opcode
-from websockets.server import ServerConnection
+
+
+try:  # websockets < 11.0
+    from websockets.connection import CLOSED, CLOSING, OPEN, Event
+    from websockets.server import ServerConnection as ServerProtocol
+except ImportError:  # websockets >= 11.0
+    from websockets.protocol import CLOSED, CLOSING, OPEN, Event
+    from websockets.server import ServerProtocol
+
 from websockets.typing import Data
 
 from sanic.log import error_logger, logger
@@ -30,7 +37,7 @@ from .frame import WebsocketFrameAssembler
 
 
 class WebsocketImplProtocol:
-    connection: ServerConnection
+    connection: ServerProtocol
     io_proto: Optional[SanicProtocol]
     loop: Optional[asyncio.AbstractEventLoop]
     max_queue: int

--- a/sanic/server/websockets/impl.py
+++ b/sanic/server/websockets/impl.py
@@ -21,10 +21,10 @@ from websockets.frames import Frame, Opcode
 
 
 try:  # websockets < 11.0
-    from websockets.connection import CLOSED, CLOSING, OPEN, Event
+    from websockets.connection import Event, State
     from websockets.server import ServerConnection as ServerProtocol
 except ImportError:  # websockets >= 11.0
-    from websockets.protocol import CLOSED, CLOSING, OPEN, Event
+    from websockets.protocol import Event, State
     from websockets.server import ServerProtocol
 
 from websockets.typing import Data
@@ -34,6 +34,11 @@ from sanic.server.protocols.base_protocol import SanicProtocol
 
 from ...exceptions import ServerError, WebsocketClosed
 from .frame import WebsocketFrameAssembler
+
+
+OPEN = State.OPEN
+CLOSING = State.CLOSING
+CLOSED = State.CLOSED
 
 
 class WebsocketImplProtocol:


### PR DESCRIPTION
I failed at naming things in the Sans-I/O layer of websockets. I ended up with `Connection` and `Protocol` swapped vs. what one would expect: `Protocol` was managing the network and `Connection` didn't know about the network.

I am about to rename in https://github.com/aaugustin/websockets/pull/1269. Since Sanic was an early adopter — actually, the first mainstream library to adopt it — it will need an update. I'm sorry.

This PR provides compatibility both with websockets 10.0 (without deprecation warnings) and with the upcoming release websockets 11.0.

----

sanic currently imports private APIs for which websockets won't provide backwards-compatibility. Specifically, it imports `OPEN`, `CLOSING`, `CLOSED` directly rather than the `State` enum. To avoid breaking Sanic users, I am planning to keep websockets 11.0 on hold until you release Sanic 22.12, with this PR included.

This is why I have to support both versions of websockets: I cannot simply release websockets 11.0 then update Sanic (bumping the dependency to websockets >= 11.0 to avoid deprecation warnings).

----

In detail:

* The first commit switches to the correct import paths for websockets 11.0, with fallback to import paths for websockets 10.x.
* The second commit renames a variable for consistency with the new name in websockets. It is optional; I can remove it if you don't want it.
* The third commit ensures that Sanic only uses public APIs of websockets, for which backwards-compatibility is guaranteed a minimum of 5 years.