### PR TITLE
Inspector by host and port

### DIFF
--- a/sanic/worker/inspector.py
+++ b/sanic/worker/inspector.py
@@ -44,7 +44,8 @@ class Inspector:
         signal_func(SIGINT, self.stop)
         signal_func(SIGTERM, self.stop)
 
-        logger.info(f"Inspector started on: {sock.getsockname()}")
+        host, port = sock.getsockname()
+        logger.info(f"Inspector started @ {host}:{port}")
         sock.settimeout(0.5)
         try:
             while self.run:


### PR DESCRIPTION
This allows the inspector to be host and port and not just path to app:

```
$ sanic localhost:6457 --inspect
```