### PR TITLE
Allow for TLS on inspector

### DIFF
--- a/sanic/cli/app.py
+++ b/sanic/cli/app.py
@@ -12,7 +12,7 @@ from sanic.app import Sanic
 from sanic.application.logo import get_logo
 from sanic.cli.arguments import Group
 from sanic.log import error_logger
-from sanic.worker.inspector import inspect
+from sanic.worker.inspector import InspectorClient
 from sanic.worker.loader import AppLoader
 
 
@@ -92,29 +92,20 @@ Or, a path to a directory to run as a simple HTTP server:
             self.args,
         )
 
+        inspector_command = (
+            self.args.inspect or self.args.inspect_raw or self.args.trigger
+        )
+        if inspector_command:
+            self._inspector(app_loader)
+            return
         try:
             app = self._get_app(app_loader)
             kwargs = self._build_run_kwargs()
         except ValueError as e:
             error_logger.exception(f"Failed to run app: {e}")
         else:
-            if self.args.inspect or self.args.inspect_raw or self.args.trigger:
-                os.environ["SANIC_IGNORE_PRODUCTION_WARNING"] = "true"
-            else:
-                for http_version in self.args.http:
-                    app.prepare(**kwargs, version=http_version)
-
-            if self.args.inspect or self.args.inspect_raw or self.args.trigger:
-                action = self.args.trigger or (
-                    "raw" if self.args.inspect_raw else "pretty"
-                )
-                inspect(
-                    app.config.INSPECTOR_HOST,
-                    app.config.INSPECTOR_PORT,
-                    action,
-                )
-                del os.environ["SANIC_IGNORE_PRODUCTION_WARNING"]
-                return
+            for http_version in self.args.http:
+                app.prepare(**kwargs, version=http_version)
 
             if self.args.single:
                 serve = Sanic.serve_single
@@ -123,6 +114,23 @@ Or, a path to a directory to run as a simple HTTP server:
             else:
                 serve = partial(Sanic.serve, app_loader=app_loader)
             serve(app)
+
+    def _inspector(self, app_loader: AppLoader):
+        os.environ["SANIC_IGNORE_PRODUCTION_WARNING"] = "true"
+        host = port = None
+        if ":" in self.args.module:
+            maybe_host, maybe_port = self.args.module.split(":", 1)
+            if maybe_port.isnumeric():
+                host, port = maybe_host, int(maybe_port)
+        if not host:
+            app = self._get_app(app_loader)
+            host, port = app.config.INSPECTOR_HOST, app.config.INSPECTOR_PORT
+
+        action = self.args.trigger or (
+            "raw" if self.args.inspect_raw else "pretty"
+        )
+        InspectorClient(host, port, self.args.secure).run(action)
+        del os.environ["SANIC_IGNORE_PRODUCTION_WARNING"]
 
     def _precheck(self):
         # Custom TLS mismatch handling for better diagnostics

--- a/sanic/cli/arguments.py
+++ b/sanic/cli/arguments.py
@@ -115,6 +115,12 @@ class ApplicationGroup(Group):
             const="shutdown",
             help=("Trigger all processes to shutdown"),
         )
+        self.container.add_argument(
+            "--secure",
+            dest="secure",
+            action="store_true",
+            help=("Whether to connect to the inspector over a TLS connection"),
+        )
 
 
 class HTTPVersionGroup(Group):

--- a/sanic/config.py
+++ b/sanic/config.py
@@ -46,6 +46,8 @@ DEFAULT_CONFIG = {
     "INSPECTOR": False,
     "INSPECTOR_HOST": "localhost",
     "INSPECTOR_PORT": 6457,
+    "INSPECTOR_TLS_KEY": _default,
+    "INSPECTOR_TLS_CERT": _default,
     "KEEP_ALIVE_TIMEOUT": 5,  # 5 seconds
     "KEEP_ALIVE": True,
     "LOCAL_CERT_CREATOR": LocalCertCreator.AUTO,
@@ -93,6 +95,8 @@ class Config(dict, metaclass=DescriptorMeta):
     INSPECTOR: bool
     INSPECTOR_HOST: str
     INSPECTOR_PORT: int
+    INSPECTOR_TLS_KEY: Union[Path, str, Default]
+    INSPECTOR_TLS_CERT: Union[Path, str, Default]
     KEEP_ALIVE_TIMEOUT: int
     KEEP_ALIVE: bool
     LOCAL_CERT_CREATOR: Union[str, LocalCertCreator]

--- a/sanic/mixins/startup.py
+++ b/sanic/mixins/startup.py
@@ -841,6 +841,8 @@ class StartupMixin(metaclass=SanicMeta):
                     worker_state,
                     primary.config.INSPECTOR_HOST,
                     primary.config.INSPECTOR_PORT,
+                    primary.config.INSPECTOR_TLS_KEY,
+                    primary.config.INSPECTOR_TLS_CERT,
                 )
                 manager.manage("Inspector", inspector, {}, transient=False)
 

--- a/sanic/worker/inspector.py
+++ b/sanic/worker/inspector.py
@@ -1,16 +1,21 @@
+import logging
+import ssl
 import sys
 
+from contextlib import contextmanager
 from datetime import datetime
 from multiprocessing.connection import Connection
+from pathlib import Path
 from signal import SIGINT, SIGTERM
 from signal import signal as signal_func
-from socket import AF_INET, SOCK_STREAM, socket, timeout
+from socket import create_connection, timeout
 from textwrap import indent
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 from sanic.application.logo import get_logo
 from sanic.application.motd import MOTDTTY
-from sanic.log import Colors, error_logger, logger
+from sanic.helpers import Default
+from sanic.log import LOGGING_CONFIG_DEFAULTS, Colors, error_logger, logger
 from sanic.server.socket import configure_socket
 
 
@@ -18,6 +23,9 @@ try:  # no cov
     from ujson import dumps, loads
 except ModuleNotFoundError:  # no cov
     from json import dumps, loads  # type: ignore
+
+OK = b"OK"
+ER = b"ER"
 
 
 class Inspector:
@@ -28,6 +36,8 @@ class Inspector:
         worker_state: Dict[str, Any],
         host: str,
         port: int,
+        tls_key: Union[Path, str, Default],
+        tls_cert: Union[Path, str, Default],
     ):
         self._publisher = publisher
         self.run = True
@@ -35,24 +45,32 @@ class Inspector:
         self.worker_state = worker_state
         self.host = host
         self.port = port
+        self.tls_key = tls_key
+        self.tls_cert = tls_cert
 
     def __call__(self) -> None:
-        sock = configure_socket(
-            {"host": self.host, "port": self.port, "unix": None, "backlog": 1}
-        )
-        assert sock
         signal_func(SIGINT, self.stop)
         signal_func(SIGTERM, self.stop)
 
-        logger.info(f"Inspector started on: {sock.getsockname()}")
-        sock.settimeout(0.5)
-        try:
+        with self.socket() as sock:
+            host, port = sock.getsockname()
+            logger.info(f"Inspector started @ {host}:{port}")
+
             while self.run:
                 try:
                     conn, _ = sock.accept()
                 except timeout:
                     continue
+                except ssl.SSLError as e:
+                    print("SSL error: ", e)
+                    continue
                 else:
+                    okay = conn.recv(2)
+                    if okay != OK:
+                        error_logger.error("Invalid start")
+                        conn.close()
+                        continue
+                    conn.send(OK)
                     action = conn.recv(64)
                     if action == b"reload":
                         conn.send(b"\n")
@@ -63,10 +81,8 @@ class Inspector:
                     else:
                         data = dumps(self.state_to_json())
                         conn.send(data.encode())
-                        conn.close()
-        finally:
-            logger.debug("Inspector closing")
-            sock.close()
+                conn.send(b"\r\n\r\n")
+                conn.close()
 
     def stop(self, *_):
         self.run = False
@@ -84,6 +100,25 @@ class Inspector:
         message = "__TERMINATE__"
         self._publisher.send(message)
 
+    @contextmanager
+    def socket(self):
+        sock = configure_socket(
+            {"host": self.host, "port": self.port, "unix": None, "backlog": 1}
+        )
+        assert sock
+        sock.settimeout(15)
+
+        if not isinstance(self.tls_key, Default) and not isinstance(
+            self.tls_cert, Default
+        ):
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            context.load_cert_chain(self.tls_cert, self.tls_key)
+            yield context.wrap_socket(sock, server_side=True)
+        else:
+            yield sock
+        logger.debug("Inspector closing")
+        sock.close()
+
     @staticmethod
     def make_safe(obj: Dict[str, Any]) -> Dict[str, Any]:
         for key, value in obj.items():
@@ -94,49 +129,72 @@ class Inspector:
         return obj
 
 
-def inspect(host: str, port: int, action: str):
-    out = sys.stdout.write
-    with socket(AF_INET, SOCK_STREAM) as sock:
+class InspectorClient:
+    def __init__(self, host: str, port: int, secure: bool):
+        self.host = host
+        self.port = port
+        self.secure = secure
+
+    @contextmanager
+    def socket(self):
+        context = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
+        error = sys.stderr.write
         try:
-            sock.connect((host, port))
-        except ConnectionRefusedError:
-            error_logger.error(
+            sock = create_connection((self.host, self.port))
+            sock.settimeout(15)
+            if self.secure:
+                sock = context.wrap_socket(sock, server_hostname="localhost")
+
+            sock.sendall(OK)
+            if sock.recv(2) != OK:
+                raise ValueError
+            yield sock
+            if not sock._closed:
+                sock.close()
+        except (
+            ConnectionRefusedError,
+            ConnectionResetError,
+            TimeoutError,
+            ValueError,
+        ):
+            error(
                 f"{Colors.RED}Could not connect to inspector at: "
-                f"{Colors.YELLOW}{(host, port)}{Colors.END}\n"
+                f"{Colors.YELLOW}{self.host}:{self.port}{Colors.END}\n"
                 "Either the application is not running, or it did not start "
-                "an inspector instance."
+                "an inspector instance.\n"
             )
-            sock.close()
             sys.exit(1)
-        sock.sendall(action.encode())
-        data = sock.recv(4096)
-    if action == "raw":
-        out(data.decode())
-    elif action == "pretty":
-        loaded = loads(data)
-        display = loaded.pop("info")
-        extra = display.pop("extra", {})
-        display["packages"] = ", ".join(display["packages"])
-        MOTDTTY(get_logo(), f"{host}:{port}", display, extra).display(
-            version=False,
-            action="Inspecting",
-            out=out,
-        )
-        for name, info in loaded["workers"].items():
-            info = "\n".join(
-                f"\t{key}: {Colors.BLUE}{value}{Colors.END}"
-                for key, value in info.items()
+
+    def run(self, action: str):
+        out = sys.stdout.write
+        logging.config.dictConfig(LOGGING_CONFIG_DEFAULTS)
+        with self.socket() as sock:
+            sock.sendall(action.encode())
+            more = True
+            data = b""
+            while more:
+                received = sock.recv(4096)
+                if received.endswith(b"\r\n\r\n"):
+                    more = False
+                data += received
+        if action == "raw":
+            out(data.decode())
+        elif action == "pretty":
+            loaded = loads(data)
+            display = loaded.pop("info")
+            extra = display.pop("extra", {})
+            display["packages"] = ", ".join(display["packages"])
+            MOTDTTY(
+                get_logo(), f"{self.host}:{self.port}", display, extra
+            ).display(
+                version=False,
+                action="Inspecting",
+                out=out,
             )
-            out(
-                "\n"
-                + indent(
-                    "\n".join(
-                        [
-                            f"{Colors.BOLD}{Colors.SANIC}{name}{Colors.END}",
-                            info,
-                        ]
-                    ),
-                    "  ",
+            for name, info in loaded["workers"].items():
+                info = "\n".join(
+                    f"\t{key}: {Colors.BLUE}{value}{Colors.END}"
+                    for key, value in info.items()
                 )
-                + "\n"
-            )
+                name = f"{Colors.BOLD}{Colors.SANIC}{name}{Colors.END}"
+                out("\n" + indent("\n".join([name, info]), "  ") + "\n")


### PR DESCRIPTION
This will allow someone to run the inspector with a TLS cert making it one step closer to being more secure to run against remote hosted applications.

I would still not advise this yet since there is no authentication mechanism yet.