### PR TITLE
Add a restart mechanism to all workers in the multiplexer

### DIFF
--- a/sanic/worker/multiplexer.py
+++ b/sanic/worker/multiplexer.py
@@ -28,7 +28,7 @@ class WorkerMultiplexer:
                 " all_workers=True"
             )
         if not name:
-            name = "__ALL_PROCESSES__" if all_workers else self.name
+            name = "__ALL_PROCESSES__:" if all_workers else self.name
         self._monitor_publisher.send(name)
 
     reload = restart  # no cov

--- a/sanic/worker/multiplexer.py
+++ b/sanic/worker/multiplexer.py
@@ -22,7 +22,7 @@ class WorkerMultiplexer:
         }
 
     def restart(self, name: str = "", all_workers: bool = False):
-        if name and all:
+        if name and all_workers:
             raise ValueError(
                 "Ambiguous restart with both a named process and"
                 " all_workers=True"

--- a/sanic/worker/multiplexer.py
+++ b/sanic/worker/multiplexer.py
@@ -21,9 +21,14 @@ class WorkerMultiplexer:
             "state": ProcessState.ACKED.name,
         }
 
-    def restart(self, name: str = ""):
+    def restart(self, name: str = "", all_workers: bool = False):
+        if name and all:
+            raise ValueError(
+                "Ambiguous restart with both a named process and"
+                " all_workers=True"
+            )
         if not name:
-            name = self.name
+            name = "__ALL_PROCESSES__" if all_workers else self.name
         self._monitor_publisher.send(name)
 
     reload = restart  # no cov


### PR DESCRIPTION
Closes #2619 

This adds a `app.m.restart(all_workers=True)` flag.