### PR TITLE
Wait for new process to ACK before termination of old on restart

### DIFF
--- a/sanic/application/ext.py
+++ b/sanic/application/ext.py
@@ -33,7 +33,7 @@ def setup_ext(app: Sanic, *, fail: bool = False, **kwargs):
         return
 
     if not getattr(app, "_ext", None):
-        Ext: Extend = getattr(sanic_ext, "Extend")
+        Ext = getattr(sanic_ext, "Extend")
         app._ext = Ext(app, **kwargs)
 
         return app.ext

--- a/sanic/application/ext.py
+++ b/sanic/application/ext.py
@@ -8,11 +8,6 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from sanic import Sanic
 
-    try:
-        from sanic_ext import Extend  # type: ignore
-    except ImportError:
-        ...
-
 
 def setup_ext(app: Sanic, *, fail: bool = False, **kwargs):
     if not app.config.AUTO_EXTEND:

--- a/sanic/compat.py
+++ b/sanic/compat.py
@@ -3,6 +3,7 @@ import os
 import signal
 import sys
 
+from enum import Enum
 from typing import Awaitable
 
 from multidict import CIMultiDict  # type: ignore
@@ -17,6 +18,31 @@ try:
     UVLOOP_INSTALLED = True
 except ImportError:
     pass
+
+
+# Python 3.11 changed the way Enum formatting works for mixed-in types.
+if sys.version_info < (3, 11, 0):
+
+    class StrEnum(str, Enum):
+        pass
+
+else:
+    from enum import StrEnum  # type: ignore # noqa
+
+
+class UpperStrEnum(StrEnum):
+    def _generate_next_value_(name, start, count, last_values):
+        return name.upper()
+
+    def __eq__(self, value: object) -> bool:
+        value = str(value).upper()
+        return super().__eq__(value)
+
+    def __hash__(self) -> int:
+        return hash(self.value)
+
+    def __str__(self) -> str:
+        return self.value
 
 
 def enable_windows_color_support():

--- a/sanic/config.py
+++ b/sanic/config.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Sequence, Union
 from warnings import filterwarnings
 
-from sanic.constants import LocalCertCreator
+from sanic.constants import LocalCertCreator, RestartOrder
 from sanic.errorpages import DEFAULT_FORMAT, check_error_format
 from sanic.helpers import Default, _default
 from sanic.http import Http
@@ -63,6 +63,7 @@ DEFAULT_CONFIG = {
     "REQUEST_MAX_SIZE": 100000000,  # 100 megabytes
     "REQUEST_TIMEOUT": 60,  # 60 seconds
     "RESPONSE_TIMEOUT": 60,  # 60 seconds
+    "RESTART_ORDER": RestartOrder.SHUTDOWN_FIRST,
     "TLS_CERT_PASSWORD": "",
     "TOUCHUP": _default,
     "USE_UVLOOP": _default,
@@ -110,6 +111,7 @@ class Config(dict, metaclass=DescriptorMeta):
     REQUEST_MAX_SIZE: int
     REQUEST_TIMEOUT: int
     RESPONSE_TIMEOUT: int
+    RESTART_ORDER: Union[str, RestartOrder]
     SERVER_NAME: str
     TLS_CERT_PASSWORD: str
     TOUCHUP: Union[Default, bool]
@@ -194,6 +196,10 @@ class Config(dict, metaclass=DescriptorMeta):
             self.LOCAL_CERT_CREATOR = LocalCertCreator[
                 self.LOCAL_CERT_CREATOR.upper()
             ]
+        elif attr == "RESTART_ORDER" and not isinstance(
+            self.RESTART_ORDER, RestartOrder
+        ):
+            self.RESTART_ORDER = RestartOrder[self.RESTART_ORDER.upper()]
         elif attr == "DEPRECATION_FILTER":
             self._configure_warnings()
 

--- a/sanic/constants.py
+++ b/sanic/constants.py
@@ -1,19 +1,9 @@
-from enum import Enum, auto
+from enum import auto
+
+from sanic.compat import UpperStrEnum
 
 
-class HTTPMethod(str, Enum):
-    def _generate_next_value_(name, start, count, last_values):
-        return name.upper()
-
-    def __eq__(self, value: object) -> bool:
-        value = str(value).upper()
-        return super().__eq__(value)
-
-    def __hash__(self) -> int:
-        return hash(self.value)
-
-    def __str__(self) -> str:
-        return self.value
+class HTTPMethod(UpperStrEnum):
 
     GET = auto()
     POST = auto()
@@ -24,13 +14,17 @@ class HTTPMethod(str, Enum):
     DELETE = auto()
 
 
-class LocalCertCreator(str, Enum):
-    def _generate_next_value_(name, start, count, last_values):
-        return name.upper()
+class LocalCertCreator(UpperStrEnum):
 
     AUTO = auto()
     TRUSTME = auto()
     MKCERT = auto()
+
+
+class RestartOrder(UpperStrEnum):
+
+    SHUTDOWN_FIRST = auto()
+    STARTUP_FIRST = auto()
 
 
 HTTP_METHODS = tuple(HTTPMethod.__members__.values())

--- a/sanic/log.py
+++ b/sanic/log.py
@@ -1,22 +1,10 @@
 import logging
 import sys
 
-from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict
+from typing import Any, Dict
 from warnings import warn
 
-from sanic.compat import is_atty
-
-
-# Python 3.11 changed the way Enum formatting works for mixed-in types.
-if sys.version_info < (3, 11, 0):
-
-    class StrEnum(str, Enum):
-        pass
-
-else:
-    if not TYPE_CHECKING:
-        from enum import StrEnum
+from sanic.compat import StrEnum, is_atty
 
 
 LOGGING_CONFIG_DEFAULTS: Dict[str, Any] = dict(  # no cov

--- a/sanic/mixins/startup.py
+++ b/sanic/mixins/startup.py
@@ -41,6 +41,7 @@ from sanic.application.motd import MOTD
 from sanic.application.state import ApplicationServerInfo, Mode, ServerStage
 from sanic.base.meta import SanicMeta
 from sanic.compat import OS_IS_WINDOWS, is_atty
+from sanic.constants import RestartOrder
 from sanic.exceptions import ServerKilled
 from sanic.helpers import Default
 from sanic.http.constants import HTTP
@@ -814,7 +815,7 @@ class StartupMixin(metaclass=SanicMeta):
                 cls._get_context(),
                 (monitor_pub, monitor_sub),
                 worker_state,
-                primary.config.RESTART_ORDER,
+                cast(RestartOrder, primary.config.RESTART_ORDER),
             )
             if cls.should_auto_reload():
                 reload_dirs: Set[Path] = primary.state.reload_dirs.union(

--- a/sanic/mixins/startup.py
+++ b/sanic/mixins/startup.py
@@ -814,6 +814,7 @@ class StartupMixin(metaclass=SanicMeta):
                 cls._get_context(),
                 (monitor_pub, monitor_sub),
                 worker_state,
+                primary.config.RESTART_ORDER,
             )
             if cls.should_auto_reload():
                 reload_dirs: Set[Path] = primary.state.reload_dirs.union(

--- a/sanic/worker/manager.py
+++ b/sanic/worker/manager.py
@@ -29,7 +29,7 @@ class WorkerManager:
         context,
         monitor_pubsub,
         worker_state,
-        restart_order: RestartOrder,
+        restart_order: RestartOrder = RestartOrder.SHUTDOWN_FIRST,
     ):
         self.num_server = number
         self.context = context
@@ -141,8 +141,8 @@ class WorkerManager:
 
     def _sync_states(self):
         for process in self.processes:
-            state = self.worker_state[process.name]["state"]
-            if process.state.name != state:
+            state = self.worker_state[process.name].get("state")
+            if state and process.state.name != state:
                 process.set_state(ProcessState[state], True)
 
     def wait_for_ack(self):  # no cov

--- a/sanic/worker/process.py
+++ b/sanic/worker/process.py
@@ -152,6 +152,13 @@ class WorkerProcess:
         termination_thread.start()
 
     def _wait_to_terminate(self):
+        logger.debug(
+            f"{Colors.BLUE}Waiting for process to be acked: "
+            f"{Colors.BOLD}{Colors.SANIC}"
+            f"%s {Colors.BLUE}[%s]{Colors.END}",
+            self.name,
+            self._old_process.pid,
+        )
         # TODO: Add a timeout?
         while self.state is not ProcessState.ACKED:
             ...

--- a/sanic/worker/process.py
+++ b/sanic/worker/process.py
@@ -188,7 +188,7 @@ class WorkerProcess:
 
 
 class Worker:
-    WORKER_PREFIX = "SANIC-"
+    WORKER_PREFIX = "Sanic-"
 
     def __init__(
         self,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -349,11 +349,11 @@ def test_get_app_does_not_exist():
     with pytest.raises(
         SanicException,
         match="Sanic app name 'does-not-exist' not found.\n"
-            "App instantiation must occur outside "
-            "if __name__ == '__main__' "
-            "block or by using an AppLoader.\nSee "
-            "https://sanic.dev/en/guide/deployment/app-loader.html"
-            " for more details."
+        "App instantiation must occur outside "
+        "if __name__ == '__main__' "
+        "block or by using an AppLoader.\nSee "
+        "https://sanic.dev/en/guide/deployment/app-loader.html"
+        " for more details.",
     ):
         Sanic.get_app("does-not-exist")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,7 +14,7 @@ from pytest import MonkeyPatch
 
 from sanic import Sanic
 from sanic.config import DEFAULT_CONFIG, Config
-from sanic.constants import LocalCertCreator
+from sanic.constants import LocalCertCreator, RestartOrder
 from sanic.exceptions import PyFileError
 
 
@@ -436,3 +436,19 @@ def test_convert_local_cert_creator(passed, expected):
     app = Sanic("Test")
     assert app.config.LOCAL_CERT_CREATOR is expected
     del os.environ["SANIC_LOCAL_CERT_CREATOR"]
+
+
+@pytest.mark.parametrize(
+    "passed,expected",
+    (
+        ("shutdown_first", RestartOrder.SHUTDOWN_FIRST),
+        ("startup_first", RestartOrder.STARTUP_FIRST),
+        ("SHUTDOWN_FIRST", RestartOrder.SHUTDOWN_FIRST),
+        ("STARTUP_FIRST", RestartOrder.STARTUP_FIRST),
+    ),
+)
+def test_convert_restart_order(passed, expected):
+    os.environ["SANIC_RESTART_ORDER"] = passed
+    app = Sanic("Test")
+    assert app.config.RESTART_ORDER is expected
+    del os.environ["SANIC_RESTART_ORDER"]

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -10,8 +10,7 @@ import pytest
 import sanic
 
 from sanic import Sanic
-from sanic.log import Colors
-from sanic.log import LOGGING_CONFIG_DEFAULTS, logger
+from sanic.log import LOGGING_CONFIG_DEFAULTS, Colors, logger
 from sanic.response import text
 
 
@@ -254,11 +253,11 @@ def test_verbosity(app, caplog, app_verbosity, log_verbosity, exists):
 
 
 def test_colors_enum_format():
-    assert f'{Colors.END}' == Colors.END.value
-    assert f'{Colors.BOLD}' == Colors.BOLD.value
-    assert f'{Colors.BLUE}' == Colors.BLUE.value
-    assert f'{Colors.GREEN}' == Colors.GREEN.value
-    assert f'{Colors.PURPLE}' == Colors.PURPLE.value
-    assert f'{Colors.RED}' == Colors.RED.value
-    assert f'{Colors.SANIC}' == Colors.SANIC.value
-    assert f'{Colors.YELLOW}' == Colors.YELLOW.value
+    assert f"{Colors.END}" == Colors.END.value
+    assert f"{Colors.BOLD}" == Colors.BOLD.value
+    assert f"{Colors.BLUE}" == Colors.BLUE.value
+    assert f"{Colors.GREEN}" == Colors.GREEN.value
+    assert f"{Colors.PURPLE}" == Colors.PURPLE.value
+    assert f"{Colors.RED}" == Colors.RED.value
+    assert f"{Colors.SANIC}" == Colors.SANIC.value
+    assert f"{Colors.YELLOW}" == Colors.YELLOW.value

--- a/tests/worker/test_reloader.py
+++ b/tests/worker/test_reloader.py
@@ -1,13 +1,18 @@
+import re
 import signal
+import threading
 
 from asyncio import Event
+from logging import DEBUG
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
 from sanic.app import Sanic
+from sanic.constants import RestartOrder
 from sanic.worker.loader import AppLoader
+from sanic.worker.process import ProcessState, WorkerProcess
 from sanic.worker.reloader import Reloader
 
 
@@ -154,3 +159,58 @@ def test_check_file(tmp_path):
     assert Reloader.check_file(current, mtimes) is False
     mtimes[current] = mtimes[current] - 1
     assert Reloader.check_file(current, mtimes) is True
+
+
+@pytest.mark.parametrize(
+    "order,expected",
+    (
+        (
+            "shutdown_first",
+            [
+                "Restarting a process",
+                "Begin restart termination",
+                "Starting a process",
+            ],
+        ),
+        (
+            "startup_first",
+            [
+                "Restarting a process",
+                "Starting a process",
+                "Begin restart termination",
+                "Process acked. Terminating",
+            ],
+        ),
+    ),
+)
+def test_default_reload_shutdown_order(monkeypatch, caplog, order, expected):
+
+    current_process = Mock()
+    worker_process = WorkerProcess(
+        lambda **_: current_process,
+        "Test",
+        lambda **_: ...,
+        {},
+        {},
+        RestartOrder[order.upper()],
+    )
+
+    def start(self):
+        worker_process.set_state(ProcessState.ACKED)
+        self._target()
+
+    monkeypatch.setattr(threading.Thread, "start", start)
+
+    with caplog.at_level(DEBUG):
+        worker_process.restart()
+
+    ansi = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+
+    def clean(msg: str):
+        msg, _ = ansi.sub("", msg).split(":", 1)
+        return msg
+
+    debug = [clean(record[2]) for record in caplog.record_tuples]
+    assert debug == expected
+    current_process.start.assert_called_once()
+    current_process.terminate.assert_called_once()


### PR DESCRIPTION
Current logic terminates a process (sends SIGINT), then starts a new process. This PR reverses the order so that it starts the new process, waits for ACK and then sends the SIGINT.

Closes #2619 