### PR TITLE
Filename normalisation of form-data/multipart file uploads (umlauts on Apple clients)

### DIFF
--- a/sanic/request.py
+++ b/sanic/request.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from sanic.app import Sanic
 
 import email.utils
+import unicodedata
 import uuid
 
 from collections import defaultdict
@@ -1084,6 +1085,14 @@ def parse_multipart_form(body, boundary):
                         form_parameters["filename*"]
                     )
                     file_name = unquote(value, encoding=encoding)
+
+                # Normalize to NFC (Apple MacOS/iOS compatibility because they send NFD)
+                # Notes:
+                # - No effect for Windows, Linux or Android clients which already send NFC
+                # - Python open() is tricky (creates files in NFC no matter which form you use)
+                if file_name is not None:
+                    file_name = unicodedata.normalize("NFC", file_name)
+
             elif form_header_field == "content-type":
                 content_type = form_header_value
                 content_charset = form_parameters.get("charset", "utf-8")

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -1086,10 +1086,12 @@ def parse_multipart_form(body, boundary):
                     )
                     file_name = unquote(value, encoding=encoding)
 
-                # Normalize to NFC (Apple MacOS/iOS compatibility because they send NFD)
+                # Normalize to NFC (Apple MacOS/iOS send NFD)
                 # Notes:
-                # - No effect for Windows, Linux or Android clients which already send NFC
-                # - Python open() is tricky (creates files in NFC no matter which form you use)
+                # - No effect for Windows, Linux or Android clients which
+                #   already send NFC
+                # - Python open() is tricky (creates files in NFC no matter
+                #   which form you use)
                 if file_name is not None:
                     file_name = unicodedata.normalize("NFC", file_name)
 

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -1293,6 +1293,24 @@ async def test_request_string_representation_asgi(app):
             "------sanic--\r\n",
             "filename_\u00A0_test",
         ),
+        # Umlaut using NFC normalization (Windows, Linux, Android)
+        (
+            "------sanic\r\n"
+            'content-disposition: form-data; filename*="utf-8\'\'filename_%C3%A4_test"; name="test"\r\n'
+            "\r\n"
+            "OK\r\n"
+            "------sanic--\r\n",
+            "filename_\u00E4_test",
+        ),
+        # Umlaut using NFD normalization (MacOS client)
+        (
+            "------sanic\r\n"
+            'content-disposition: form-data; filename*="utf-8\'\'filename_a%CC%88_test"; name="test"\r\n'
+            "\r\n"
+            "OK\r\n"
+            "------sanic--\r\n",
+            "filename_\u00E4_test",  # Sanic should normalize to NFC
+        ),
     ],
 )
 def test_request_multipart_files(app, payload, filename):


### PR DESCRIPTION
Normalise filenames to Unicode NFC, such that Mac and iOS clients behave identically to other operating systems. Normally Apple devices use NFD which may cause trouble on other systems.

This patch only affects `form-data/multipart` file uploads, not downloads nor any uploads handled by client side Javascript (which may need additional normalisation by app developers). The problem only affects filenames (not text input fields and such which always seem to use NFC).

This affects specifically umlauts and other letters that may be decomposed as two characters. For instance, ä can be represented as `\u00E4` (NFC) or as `a\u0308` (NFD) i.e. `a` with COMBINING DIARESIS.

Some applications may already be doing such normalisation, and should not be affected (only the same work done twice). Otherwise without this PR applications see differently encoded names depending on which OS the client is running, but this patch removes the disparity, and the changes are not expected to be breaking.

On the downloading side of things Mac browsers appear to be accepting either NFC or NFD, converting them to NFD as is native for Apple devices, thus no changes are needed there. NFC should work for everything.

## A bit of a background on the filesystem side (not directly affecting Sanic)

```python
# Linux sees NFC and NFD as separate files
>>> open("foo\u00E4", "w").write("NFC\n")
>>> open("fooa\u0308", "w").write("NFD\n")

# ls foo*
fooä  fooä

# cat foo*
NFD
NFC
```

MacOS considers them the same, although everything *should* be in NFD. Python's `open()` on MacOS behaves a bit strange because no matter how the filename is passed (even as bytes), new files are created in NFC.

```python
# Trying very hard on MacOS to get NFD filename but it still creates NFC name
>>> open("fooa\u0308".encode(), "w").write("NFD\n")
```

However, reading files or overwriting existing files understands either form from the filesystem and preserves it as well (similar to case-insensitivity and probably a side effect of implementing that).

Those who already find incorrectly encoded filenames on their system should find the convmv utility helpful, as it can mass convert names either way:

```fish
convmv -f UTF-8 -t UTF-8 --nfc ...
```
