### PR TITLE
Reload interval on class variable

### DIFF
--- a/sanic/mixins/startup.py
+++ b/sanic/mixins/startup.py
@@ -825,7 +825,7 @@ class StartupMixin(metaclass=SanicMeta):
                 reload_dirs: Set[Path] = primary.state.reload_dirs.union(
                     *(app.state.reload_dirs for app in apps)
                 )
-                reloader = Reloader(monitor_pub, 1.0, reload_dirs, app_loader)
+                reloader = Reloader(monitor_pub, 0, reload_dirs, app_loader)
                 manager.manage("Reloader", reloader, {}, transient=False)
 
             inspector = None

--- a/sanic/worker/reloader.py
+++ b/sanic/worker/reloader.py
@@ -17,6 +17,8 @@ from sanic.worker.loader import AppLoader
 
 
 class Reloader:
+    INTERVAL = 1.0  # seconds
+
     def __init__(
         self,
         publisher: Connection,
@@ -25,7 +27,7 @@ class Reloader:
         app_loader: AppLoader,
     ):
         self._publisher = publisher
-        self.interval = interval
+        self.interval = interval or self.INTERVAL
         self.reload_dirs = reload_dirs
         self.run = True
         self.app_loader = app_loader


### PR DESCRIPTION
Replaces #2567 by moving the interval to the class so that it is possible to configure, but does not bloat the config namespace.

```py
from sanic.worker.reloader import Reloader

Reloader.INTERVAL = 5.0
```