### PR TITLE
Remove deprecated property in blueprint

### DIFF
--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -304,9 +304,6 @@ class Blueprint(BaseSanic):
 
         # Routes
         for future in self._future_routes:
-            # attach the blueprint name to the handler so that it can be
-            # prefixed properly in the router
-            future.handler.__blueprintname__ = self.name
             # Prepend the blueprint URI prefix if available
             uri = self._setup_uri(future.uri, url_prefix)
 


### PR DESCRIPTION
The `future.handler.__blueprintname__` is not used anymore in the blueprint module, hence, removing legacy code.

Fixes #2442

Signed-off-by: Rodolfo Olivieri <rodolfo.olivieri3@gmail.com>