### PR TITLE
Color tweaks for Error Handling. 

### DIFF
--- a/sanic/pages/base.py
+++ b/sanic/pages/base.py
@@ -20,7 +20,7 @@ class BasePage(ABC, metaclass=CSS):  # no cov
         return self.CSS
 
     def render(self) -> str:
-        self.doc = Document(self.TITLE, lang="en")
+        self.doc = Document(self.TITLE, lang="en", id="sanic")
         self._head()
         self._body()
         self._foot()

--- a/sanic/pages/styles/BasePage.css
+++ b/sanic/pages/styles/BasePage.css
@@ -2,10 +2,10 @@
 
 :root {
     --sanic: #ff0d68;
-    --sanic-blue: #0369a1;
-    --sanic-yellow: #ffde41;
-    --sanic-purple: #7e22ce;
-    --sanic-green: #4d7c0f;
+    --sanic-blue: #0092FF;
+    --sanic-yellow: #FFE900;
+    --sanic-purple: #833FE3;
+    --sanic-green: #37ae6f;
     --sanic-background: #f1f5f9;
     --sanic-text: #1f2937;
     --sanic-tab-background: #fff;
@@ -18,15 +18,10 @@
 
 @media (prefers-color-scheme: dark) {
     :root {
-        --sanic: #ff0d68;
-        --sanic-blue: #f08d49;
-        --sanic-yellow: #ffde41;
-        --sanic-purple: #cc99cd;
-        --sanic-green: #7ec699;
-        --sanic-background: hsl(0, 0%, 10%);
-        /*--sanic-background: #2d2d2d;*/
-        /*--sanic-background: #111;*/
-        --sanic-text: rgba(255, 255, 255, 0.9);
+        --sanic-purple: #D246DE;
+        --sanic-green: #16DB93;
+        --sanic-background: #111;
+        --sanic-text: #e7e7e7;
         --sanic-tab-background: #484848;
         --sanic-tab-text: #e1e1e1;
         --sanic-tab-shadow: #000;

--- a/sanic/pages/styles/BasePage.css
+++ b/sanic/pages/styles/BasePage.css
@@ -13,6 +13,7 @@
     --sanic-tab-shadow: #adadad;
     --sanic-highlight-background: var(--sanic-yellow);
     --sanic-highlight-text: var(--sanic-text);
+    --sanic-header-background: #000;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -22,13 +23,14 @@
         --sanic-yellow: #ffde41;
         --sanic-purple: #b19bf8;
         --sanic-green: #37d971;
-        --sanic-background: #2b2f3b;
-        --sanic-text: #f1f5f9;
-        --sanic-tab-background: #383d4d;
-        --sanic-tab-text: #cbd5e1;
+        --sanic-background: #222;
+        --sanic-text: #e7e7e7;
+        --sanic-tab-background: #484848;
+        --sanic-tab-text: #e1e1e1;
         --sanic-tab-shadow: #000;
         --sanic-highlight-background: var(--sanic-yellow);
-        --sanic-highlight-text: #1f2937;
+        --sanic-highlight-text: #000;
+        --sanic-header-background: var(--sanic);
     }
 }
 

--- a/sanic/pages/styles/BasePage.css
+++ b/sanic/pages/styles/BasePage.css
@@ -1,7 +1,7 @@
 /** BasePage **/
 html {
     font: 16px sans-serif;
-    background: #eee;
+    background: #f1f5f9;
     color: #111;
     scrollbar-gutter: stable;
     overflow: hidden auto;
@@ -11,10 +11,10 @@ body {
     margin: 0;
     font-size: 1.25rem;
     --sanic: #ff0d68;
-    --sanic-blue: #0092FF;
+    --sanic-blue: #0369a1;
     --sanic-yellow: #FFE900;
-    --sanic-purple: #833FE3;
-    --sanic-green: #16DB93;
+    --sanic-purple: #a21caf;
+    --sanic-green: #166534;
 }
 
 body>* {

--- a/sanic/pages/styles/BasePage.css
+++ b/sanic/pages/styles/BasePage.css
@@ -125,13 +125,14 @@ span.icon {
     }
 }
 
-pre, code {
+#sanic pre, #sanic code {
     font-family: "Fira Code",
     "Source Code Pro",
     Menlo,
+    Meslo,
     Monaco,
     Consolas,
     Lucida Console,
-    monospace !important;
-    font-size: 0.8rem !important;
+    monospace;
+    font-size: 0.8rem;
 }

--- a/sanic/pages/styles/BasePage.css
+++ b/sanic/pages/styles/BasePage.css
@@ -16,6 +16,7 @@ body {
     --sanic-yellow: #FFE900;
     --sanic-purple: #7e22ce;
     --sanic-green: #4d7c0f;
+    --sanic-tab: #ffffff;
 }
 
 body>* {
@@ -98,6 +99,7 @@ span.icon {
         --sanic-yellow: #ffde41;
         --sanic-purple: #b19bf8;
         --sanic-green: #37d971;
+        --sanic-tab: #e8e3e3;
     }
 
     html {

--- a/sanic/pages/styles/BasePage.css
+++ b/sanic/pages/styles/BasePage.css
@@ -34,6 +34,7 @@ body>* {
 }
 main {
     min-height: 70vh;  /* Make sure the footer is closer to bottom */
+    padding: 1rem 2.5rem; /* Generous padding for readability */
 }
 .smalltext {
     font-size: 1.0rem;

--- a/sanic/pages/styles/BasePage.css
+++ b/sanic/pages/styles/BasePage.css
@@ -1,8 +1,33 @@
 /** BasePage **/
+
+:root {
+    --sanic: #ff0d68;
+    --sanic-blue: #0369a1;
+    --sanic-yellow: #FFE900;
+    --sanic-purple: #7e22ce;
+    --sanic-green: #4d7c0f;
+    --sanic-tab: #ffffff;
+    --sanic-background: #f1f5f9;
+    --sanic-text: #0f172a;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --sanic: #ef4444;
+        --sanic-blue: #38bdf8;
+        --sanic-yellow: #ffde41;
+        --sanic-purple: #b19bf8;
+        --sanic-green: #37d971;
+        --sanic-tab: #e8e3e3;
+        --sanic-background: #2b2f3b;
+        --sanic-text: #ccc;
+    }
+}
+
 html {
     font: 16px sans-serif;
-    background: #f1f5f9;
-    color: #0f172a;
+    background: var(--sanic-background);
+    color: var(--sanic-text);
     scrollbar-gutter: stable;
     overflow: hidden auto;
 }
@@ -11,20 +36,14 @@ body {
     margin: 0;
     font-size: 1.25rem;
     line-height: 125%;
-    --sanic: #ff0d68;
-    --sanic-blue: #0369a1;
-    --sanic-yellow: #FFE900;
-    --sanic-purple: #7e22ce;
-    --sanic-green: #4d7c0f;
-    --sanic-tab: #ffffff;
 }
 
-body>* {
+body > * {
     padding: 1rem 2vw;
 }
 
 @media (max-width: 1000px) {
-    body>* {
+    body > * {
         padding: 0.5rem 1.5vw;
     }
 
@@ -33,10 +52,12 @@ body>* {
         font-size: calc(6px + 10 * 100vw / 1000);
     }
 }
+
 main {
-    min-height: 70vh;  /* Make sure the footer is closer to bottom */
+    min-height: 70vh; /* Make sure the footer is closer to bottom */
     padding: 1rem 2.5rem; /* Generous padding for readability */
 }
+
 .smalltext {
     font-size: 1.0rem;
 }
@@ -92,21 +113,6 @@ span.icon {
 
 
 @media (prefers-color-scheme: dark) {
-
-    body {
-        --sanic: #ef4444;
-        --sanic-blue: #38bdf8;
-        --sanic-yellow: #ffde41;
-        --sanic-purple: #b19bf8;
-        --sanic-green: #37d971;
-        --sanic-tab: #e8e3e3;
-    }
-
-    html {
-        background: #2b2f3b;
-        color: #ccc;
-    }
-
     #logo-simple path:last-child {
         fill: #e1e1e1;
     }

--- a/sanic/pages/styles/BasePage.css
+++ b/sanic/pages/styles/BasePage.css
@@ -2,7 +2,7 @@
 html {
     font: 16px sans-serif;
     background: #f1f5f9;
-    color: #111;
+    color: #0f172a;
     scrollbar-gutter: stable;
     overflow: hidden auto;
 }

--- a/sanic/pages/styles/BasePage.css
+++ b/sanic/pages/styles/BasePage.css
@@ -6,10 +6,11 @@
     --sanic-yellow: #ffde41;
     --sanic-purple: #7e22ce;
     --sanic-green: #4d7c0f;
-    --sanic-background: #e2e8f0;
+    --sanic-background: #f1f5f9;
     --sanic-text: #1f2937;
-    --sanic-tab-background: #f8fafc;
+    --sanic-tab-background: #fff;
     --sanic-tab-text: #0f172a;
+    --sanic-tab-shadow: #adadad;
     --sanic-highlight-background: var(--sanic-yellow);
     --sanic-highlight-text: var(--sanic-text);
 }
@@ -25,6 +26,7 @@
         --sanic-text: #f1f5f9;
         --sanic-tab-background: #383d4d;
         --sanic-tab-text: #cbd5e1;
+        --sanic-tab-shadow: #000;
         --sanic-highlight-background: var(--sanic-yellow);
         --sanic-highlight-text: #1f2937;
     }

--- a/sanic/pages/styles/BasePage.css
+++ b/sanic/pages/styles/BasePage.css
@@ -89,8 +89,17 @@ span.icon {
 
 
 @media (prefers-color-scheme: dark) {
+
+    body {
+        --sanic: #ef4444;
+        --sanic-blue: #38bdf8;
+        --sanic-yellow: #FFE900;
+        --sanic-purple: #a78bfa;
+        --sanic-green: #4ade80;
+    }
+
     html {
-        background: #111;
+        background: #2b2f3b;
         color: #ccc;
     }
 

--- a/sanic/pages/styles/BasePage.css
+++ b/sanic/pages/styles/BasePage.css
@@ -23,9 +23,10 @@
         --sanic-yellow: #ffde41;
         --sanic-purple: #cc99cd;
         --sanic-green: #7ec699;
-        --sanic-background: #2d2d2d;
+        --sanic-background: hsl(0, 0%, 10%);
+        /*--sanic-background: #2d2d2d;*/
         /*--sanic-background: #111;*/
-        --sanic-text: #e7e7e7;
+        --sanic-text: rgba(255, 255, 255, 0.9);
         --sanic-tab-background: #484848;
         --sanic-tab-text: #e1e1e1;
         --sanic-tab-shadow: #000;
@@ -127,4 +128,15 @@ span.icon {
     #logo-simple path:last-child {
         fill: #e1e1e1;
     }
+}
+
+pre, code {
+    font-family: "Fira Code",
+    "Source Code Pro",
+    Menlo,
+    Monaco,
+    Consolas,
+    Lucida Console,
+    monospace !important;
+    font-size: 0.8rem !important;
 }

--- a/sanic/pages/styles/BasePage.css
+++ b/sanic/pages/styles/BasePage.css
@@ -95,9 +95,9 @@ span.icon {
     body {
         --sanic: #ef4444;
         --sanic-blue: #38bdf8;
-        --sanic-yellow: #FFE900;
-        --sanic-purple: #a78bfa;
-        --sanic-green: #22c55e;
+        --sanic-yellow: #ffde41;
+        --sanic-purple: #b19bf8;
+        --sanic-green: #37d971;
     }
 
     html {

--- a/sanic/pages/styles/BasePage.css
+++ b/sanic/pages/styles/BasePage.css
@@ -108,9 +108,3 @@ span.icon {
         fill: #e1e1e1;
     }
 }
-
-/* tracerite specific */
-
-.traceback-labels {
-    font-size: 1.0rem;
-}

--- a/sanic/pages/styles/BasePage.css
+++ b/sanic/pages/styles/BasePage.css
@@ -10,11 +10,12 @@ html {
 body {
     margin: 0;
     font-size: 1.25rem;
+    line-height: 125%;
     --sanic: #ff0d68;
     --sanic-blue: #0369a1;
     --sanic-yellow: #FFE900;
-    --sanic-purple: #a21caf;
-    --sanic-green: #166534;
+    --sanic-purple: #7e22ce;
+    --sanic-green: #4d7c0f;
 }
 
 body>* {
@@ -95,7 +96,7 @@ span.icon {
         --sanic-blue: #38bdf8;
         --sanic-yellow: #FFE900;
         --sanic-purple: #a78bfa;
-        --sanic-green: #4ade80;
+        --sanic-green: #22c55e;
     }
 
     html {
@@ -106,4 +107,10 @@ span.icon {
     #logo-simple path:last-child {
         fill: #e1e1e1;
     }
+}
+
+/* tracerite specific */
+
+.traceback-labels {
+    font-size: 1.0rem;
 }

--- a/sanic/pages/styles/BasePage.css
+++ b/sanic/pages/styles/BasePage.css
@@ -17,7 +17,7 @@
 
 @media (prefers-color-scheme: dark) {
     :root {
-        --sanic: #ef4444;
+        --sanic: #ff0d68;
         --sanic-blue: #38bdf8;
         --sanic-yellow: #ffde41;
         --sanic-purple: #b19bf8;

--- a/sanic/pages/styles/BasePage.css
+++ b/sanic/pages/styles/BasePage.css
@@ -19,18 +19,19 @@
 @media (prefers-color-scheme: dark) {
     :root {
         --sanic: #ff0d68;
-        --sanic-blue: #38bdf8;
+        --sanic-blue: #f08d49;
         --sanic-yellow: #ffde41;
-        --sanic-purple: #b19bf8;
-        --sanic-green: #37d971;
-        --sanic-background: #222;
+        --sanic-purple: #cc99cd;
+        --sanic-green: #7ec699;
+        --sanic-background: #2d2d2d;
+        /*--sanic-background: #111;*/
         --sanic-text: #e7e7e7;
         --sanic-tab-background: #484848;
         --sanic-tab-text: #e1e1e1;
         --sanic-tab-shadow: #000;
         --sanic-highlight-background: var(--sanic-yellow);
         --sanic-highlight-text: #000;
-        --sanic-header-background: var(--sanic);
+        --sanic-header-background: #000;
     }
 }
 

--- a/sanic/pages/styles/BasePage.css
+++ b/sanic/pages/styles/BasePage.css
@@ -3,12 +3,15 @@
 :root {
     --sanic: #ff0d68;
     --sanic-blue: #0369a1;
-    --sanic-yellow: #FFE900;
+    --sanic-yellow: #ffde41;
     --sanic-purple: #7e22ce;
     --sanic-green: #4d7c0f;
-    --sanic-tab: #ffffff;
-    --sanic-background: #f1f5f9;
-    --sanic-text: #0f172a;
+    --sanic-background: #e2e8f0;
+    --sanic-text: #1f2937;
+    --sanic-tab-background: #f8fafc;
+    --sanic-tab-text: #0f172a;
+    --sanic-highlight-background: var(--sanic-yellow);
+    --sanic-highlight-text: var(--sanic-text);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -18,9 +21,12 @@
         --sanic-yellow: #ffde41;
         --sanic-purple: #b19bf8;
         --sanic-green: #37d971;
-        --sanic-tab: #e8e3e3;
         --sanic-background: #2b2f3b;
-        --sanic-text: #ccc;
+        --sanic-text: #f1f5f9;
+        --sanic-tab-background: #383d4d;
+        --sanic-tab-text: #cbd5e1;
+        --sanic-highlight-background: var(--sanic-yellow);
+        --sanic-highlight-text: #1f2937;
     }
 }
 

--- a/sanic/pages/styles/ErrorPage.css
+++ b/sanic/pages/styles/ErrorPage.css
@@ -5,12 +5,15 @@
     text-align: justify;
     /*text-justify: both;*/
 }
+
 #enduser a {
     color: var(--sanic-blue);
 }
+
 #enduser p:last-child {
     text-align: right;
 }
+
 summary {
     margin-top: 3em;
     color: var(--sanic-blue);
@@ -37,10 +40,14 @@ summary {
     background: var(--tracerite-tab) !important;
     color: var(--tracerite-tab-text) !important;
     transition: 0.3s;
+    cursor: pointer;
 }
 
+.tracerite .traceback-labels {
+    padding-top: 5px;
+}
 .tracerite .traceback-labels button:hover {
-    filter: brightness(120%);
+    filter: contrast(150%) brightness(120%) drop-shadow(0 -0 2px var(--sanic-tab-shadow));
 }
 
 .tracerite .traceback-details mark span {
@@ -52,11 +59,13 @@ summary {
 h1 {
     /*margin-left: -1.5rem;  !* Emoji partially in the left margin *!*/
 }
+
 h2 {
     margin: 1em 0 0.2em 0;
     font-size: 1.25rem;
     color: var(--sanic-text);
 }
+
 dl.key-value-table {
     width: 100%;
     margin: 0;
@@ -65,13 +74,16 @@ dl.key-value-table {
     grid-gap: .3em;
     white-space: pre-wrap;
 }
+
 dl.key-value-table * {
     margin: 0;
 }
+
 dl.key-value-table dt {
     color: #888;
     word-break: break-word;
 }
+
 dl.key-value-table dd {
-    word-break: break-all;  /* Better breaking for cookies header and such */
+    word-break: break-all; /* Better breaking for cookies header and such */
 }

--- a/sanic/pages/styles/ErrorPage.css
+++ b/sanic/pages/styles/ErrorPage.css
@@ -55,6 +55,9 @@ summary {
     color: var(--sanic-highlight-text);
 }
 
+header {
+    background: var(--sanic-header-background);
+}
 
 h1 {
     /*margin-left: -1.5rem;  !* Emoji partially in the left margin *!*/

--- a/sanic/pages/styles/ErrorPage.css
+++ b/sanic/pages/styles/ErrorPage.css
@@ -34,11 +34,11 @@ summary {
     margin: 0.5rem 0 !important;
 }
 
-.tracerite .traceback-labels button {
-    font-size: 0.8rem !important;
-    line-height: 120% !important;
-    background: var(--tracerite-tab) !important;
-    color: var(--tracerite-tab-text) !important;
+#sanic .tracerite .traceback-labels button {
+    font-size: 0.8rem;
+    line-height: 120%;
+    background: var(--tracerite-tab);
+    color: var(--tracerite-tab-text);
     transition: 0.3s;
     cursor: pointer;
 }
@@ -50,9 +50,9 @@ summary {
     filter: contrast(150%) brightness(120%) drop-shadow(0 -0 2px var(--sanic-tab-shadow));
 }
 
-.tracerite .traceback-details mark span {
-    background: var(--sanic-highlight-background) !important;
-    color: var(--sanic-highlight-text) !important;
+#sanic .tracerite .traceback-details mark span {
+    background: var(--sanic-highlight-background);
+    color: var(--sanic-highlight-text);
 }
 
 header {

--- a/sanic/pages/styles/ErrorPage.css
+++ b/sanic/pages/styles/ErrorPage.css
@@ -24,6 +24,11 @@ summary {
     --tracerite-exception: var(--sanic);
     --tracerite-highlight: var(--sanic-yellow);
 }
+
+.tracerite > h3 {
+    margin: 0.5rem 0 !important;
+}
+
 h1 {
     /*margin-left: -1.5rem;  !* Emoji partially in the left margin *!*/
 }

--- a/sanic/pages/styles/ErrorPage.css
+++ b/sanic/pages/styles/ErrorPage.css
@@ -25,7 +25,7 @@ summary {
     --tracerite-highlight: var(--sanic-yellow);
 }
 h1 {
-    margin-left: -1.5rem;  /* Emoji partially in the left margin */
+    /*margin-left: -1.5rem;  !* Emoji partially in the left margin *!*/
 }
 h2 {
     margin: 1em 0 0.2em 0;

--- a/sanic/pages/styles/ErrorPage.css
+++ b/sanic/pages/styles/ErrorPage.css
@@ -23,6 +23,7 @@ summary {
     --tracerite-type: var(--sanic-purple);
     --tracerite-exception: var(--sanic);
     --tracerite-highlight: var(--sanic-yellow);
+    --tracerite-tab: var(--sanic-tab);
 }
 
 .tracerite > h3 {

--- a/sanic/pages/styles/ErrorPage.css
+++ b/sanic/pages/styles/ErrorPage.css
@@ -3,7 +3,7 @@
     max-width: 30em;
     margin: 5em auto 5em auto;
     text-align: justify;
-    text-justify: both;
+    /*text-justify: both;*/
 }
 #enduser a {
     color: var(--sanic-blue);

--- a/sanic/pages/styles/ErrorPage.css
+++ b/sanic/pages/styles/ErrorPage.css
@@ -23,12 +23,31 @@ summary {
     --tracerite-type: var(--sanic-purple);
     --tracerite-exception: var(--sanic);
     --tracerite-highlight: var(--sanic-yellow);
-    --tracerite-tab: var(--sanic-tab);
+    --tracerite-tab: var(--sanic-tab-background);
+    --tracerite-tab-text: var(--sanic-tab-text);
 }
 
 .tracerite > h3 {
     margin: 0.5rem 0 !important;
 }
+
+.tracerite .traceback-labels button {
+    font-size: 0.8rem !important;
+    line-height: 120% !important;
+    background: var(--tracerite-tab) !important;
+    color: var(--tracerite-tab-text) !important;
+    transition: 0.3s;
+}
+
+.tracerite .traceback-labels button:hover {
+    filter: brightness(120%);
+}
+
+.tracerite .traceback-details mark span {
+    background: var(--sanic-highlight-background);
+    color: var(--sanic-highlight-text);
+}
+
 
 h1 {
     /*margin-left: -1.5rem;  !* Emoji partially in the left margin *!*/
@@ -36,7 +55,7 @@ h1 {
 h2 {
     margin: 1em 0 0.2em 0;
     font-size: 1.25rem;
-    color: #888;
+    color: var(--sanic-text);
 }
 dl.key-value-table {
     width: 100%;

--- a/sanic/pages/styles/ErrorPage.css
+++ b/sanic/pages/styles/ErrorPage.css
@@ -51,8 +51,8 @@ summary {
 }
 
 .tracerite .traceback-details mark span {
-    background: var(--sanic-highlight-background);
-    color: var(--sanic-highlight-text);
+    background: var(--sanic-highlight-background) !important;
+    color: var(--sanic-highlight-text) !important;
 }
 
 header {


### PR DESCRIPTION
What’s done:

- Lower contrast in dark theme
- Color tweaks
- Added variables for the following so they can be set via variables:
  - text
  - background
  - tab text
  - tab background
  - tab shadow (this is mainly for hover state in light theme)
  - highlight text
  - highlight background (these two properties allow better control of highlight in light / dark theme — subsequently I have decided to keep the same values for now)
- Moved all the color variable config to the top of the styles under `:root {}` and the dark theme config immediately follows. For me this makes color management easily to deal with.
- Added main container padding so it’s not so claustrophobic

## CSS for the error page 

I had to add some `!important` styles. But as mentioned on Discord, it would be better if the container on the page would have an ID so that CSS can just use `#sanic-error` to take precedence over the styles from `tracerite`.

Right now, these `!important` CSS values are mainly used to override the styles from `tracerite`.

## Light Theme Screenshot

![sanic-error-light](https://user-images.githubusercontent.com/25040297/217688177-bfcceb0e-5f8c-4586-a576-d48d21234509.png)

## Dark Theme Screenshot

![sanic-error-dark](https://user-images.githubusercontent.com/25040297/217688203-e5f0180e-4846-401f-9032-b923dc1f7df7.png)

## Further Notes

I’m not sure how far I am allowed to tweak these so I kept it to colors only and some minor typographic issues.