### PR TITLE
FIX: check whether object is bytes for shared_ctx

### DIFF
--- a/sanic/types/shared_ctx.py
+++ b/sanic/types/shared_ctx.py
@@ -38,7 +38,7 @@ class SharedContext(SimpleNamespace):
         if not any(
             module.startswith(prefix)
             for prefix in ("multiprocessing", "ctypes")
-        ):
+        ) and not type(value) is bytes:
             error_logger.warning(
                 f"{Colors.YELLOW}Unsafe object {Colors.PURPLE}{name} "
                 f"{Colors.YELLOW}with type {Colors.PURPLE}{type(value)} "

--- a/sanic/types/shared_ctx.py
+++ b/sanic/types/shared_ctx.py
@@ -40,7 +40,7 @@ class SharedContext(SimpleNamespace):
                 module.startswith(prefix)
                 for prefix in ("multiprocessing", "ctypes")
             )
-            and not type(value) is bytes
+            and not isinstance(value, bytes)
         ):
             error_logger.warning(
                 f"{Colors.YELLOW}Unsafe object {Colors.PURPLE}{name} "

--- a/sanic/types/shared_ctx.py
+++ b/sanic/types/shared_ctx.py
@@ -35,10 +35,13 @@ class SharedContext(SimpleNamespace):
             module = value.__module__
         except AttributeError:
             module = ""
-        if not any(
-            module.startswith(prefix)
-            for prefix in ("multiprocessing", "ctypes")
-        ) and not type(value) is bytes:
+        if (
+            not any(
+                module.startswith(prefix)
+                for prefix in ("multiprocessing", "ctypes")
+            )
+            and not type(value) is bytes
+        ):
             error_logger.warning(
                 f"{Colors.YELLOW}Unsafe object {Colors.PURPLE}{name} "
                 f"{Colors.YELLOW}with type {Colors.PURPLE}{type(value)} "

--- a/sanic/types/shared_ctx.py
+++ b/sanic/types/shared_ctx.py
@@ -35,13 +35,10 @@ class SharedContext(SimpleNamespace):
             module = value.__module__
         except AttributeError:
             module = ""
-        if (
-            not any(
-                module.startswith(prefix)
-                for prefix in ("multiprocessing", "ctypes")
-            )
-            and not isinstance(value, bytes)
-        ):
+        if not any(
+            module.startswith(prefix)
+            for prefix in ("multiprocessing", "ctypes")
+        ) and not isinstance(value, bytes):
             error_logger.warning(
                 f"{Colors.YELLOW}Unsafe object {Colors.PURPLE}{name} "
                 f"{Colors.YELLOW}with type {Colors.PURPLE}{type(value)} "

--- a/tests/worker/test_shared_ctx.py
+++ b/tests/worker/test_shared_ctx.py
@@ -67,10 +67,8 @@ def test_set_items_in_worker(item: Any, caplog):
     assert ctx.is_locked is False
     assert len(caplog.record_tuples) == 0
 
-@pytest.mark.parametrize(
-    "item",
-    u"test"
-)
+
+@pytest.mark.parametrize("item", "test")
 def test_no_bytes_warning(item: bytes, caplog):
     ctx = SharedContext()
 
@@ -81,10 +79,8 @@ def test_no_bytes_warning(item: bytes, caplog):
     assert type(ctx.item) is bytes
     assert "Unsafe object" not in caplog.text
 
-@pytest.mark.parametrize(
-    "item",
-    u"test"
-)
+
+@pytest.mark.parametrize("item", "test")
 def test_bytes_warning(item: bytes, caplog):
     ctx = SharedContext()
 
@@ -94,7 +90,6 @@ def test_bytes_warning(item: bytes, caplog):
     assert ctx.is_locked is False
     assert type(ctx.item) is not bytes
     assert "Unsafe object" in caplog.text
-
 
 
 def test_lock():

--- a/tests/worker/test_shared_ctx.py
+++ b/tests/worker/test_shared_ctx.py
@@ -69,7 +69,7 @@ def test_set_items_in_worker(item: Any, caplog):
 
 
 @pytest.mark.parametrize("item", "test")
-def test_no_bytes_warning(item: bytes, caplog):
+def test_no_bytes_warning(item: str, caplog):
     ctx = SharedContext()
 
     with caplog.at_level(logging.INFO):
@@ -81,14 +81,14 @@ def test_no_bytes_warning(item: bytes, caplog):
 
 
 @pytest.mark.parametrize("item", "test")
-def test_bytes_warning(item: bytes, caplog):
+def test_bytes_warning(item: str, caplog):
     ctx = SharedContext()
 
     with caplog.at_level(logging.INFO):
         ctx.item = item
 
     assert ctx.is_locked is False
-    assert isinstance(ctx.item, bytes)
+    assert not isinstance(ctx.item, bytes)
     assert "Unsafe object" in caplog.text
 
 

--- a/tests/worker/test_shared_ctx.py
+++ b/tests/worker/test_shared_ctx.py
@@ -67,6 +67,35 @@ def test_set_items_in_worker(item: Any, caplog):
     assert ctx.is_locked is False
     assert len(caplog.record_tuples) == 0
 
+@pytest.mark.parametrize(
+    "item",
+    u"test"
+)
+def test_no_bytes_warning(item: bytes, caplog):
+    ctx = SharedContext()
+
+    with caplog.at_level(logging.INFO):
+        ctx.item = bytes(item, "utf-8")
+
+    assert ctx.is_locked is False
+    assert type(ctx.item) is bytes
+    assert "Unsafe object" not in caplog.text
+
+@pytest.mark.parametrize(
+    "item",
+    u"test"
+)
+def test_bytes_warning(item: bytes, caplog):
+    ctx = SharedContext()
+
+    with caplog.at_level(logging.INFO):
+        ctx.item = item
+
+    assert ctx.is_locked is False
+    assert type(ctx.item) is not bytes
+    assert "Unsafe object" in caplog.text
+
+
 
 def test_lock():
     ctx = SharedContext()

--- a/tests/worker/test_shared_ctx.py
+++ b/tests/worker/test_shared_ctx.py
@@ -76,7 +76,7 @@ def test_no_bytes_warning(item: bytes, caplog):
         ctx.item = bytes(item, "utf-8")
 
     assert ctx.is_locked is False
-    assert type(ctx.item) is bytes
+    assert isinstance(ctx.item, bytes)
     assert "Unsafe object" not in caplog.text
 
 
@@ -88,7 +88,7 @@ def test_bytes_warning(item: bytes, caplog):
         ctx.item = item
 
     assert ctx.is_locked is False
-    assert type(ctx.item) is not bytes
+    assert isinstance(ctx.item, bytes)
     assert "Unsafe object" in caplog.text
 
 


### PR DESCRIPTION
Don't warn if bytes object is added to shared_ctx. Fixes #2690 