### PR TITLE
Stricter charset handling and escaping of request URLs

### DIFF
--- a/sanic/asgi.py
+++ b/sanic/asgi.py
@@ -143,14 +143,9 @@ class ASGIApp:
         if scope["type"] == "lifespan":
             await instance.lifespan(scope, receive, send)
         else:
-            path = (
-                scope["path"][1:]
-                if scope["path"].startswith("/")
-                else scope["path"]
-            )
-            url = "/".join([scope.get("root_path", ""), quote(path)])
-            url_bytes = url.encode("latin-1")
-            url_bytes += b"?" + scope["query_string"]
+            url_bytes, query = scope["raw_path"], scope["query_string"]
+            if query:
+                url_bytes = b"%b?%b" % (url_bytes, query)
 
             if scope["type"] == "http":
                 version = scope["http_version"]

--- a/sanic/http/http1.py
+++ b/sanic/http/http1.py
@@ -12,6 +12,7 @@ from asyncio import CancelledError, sleep
 from sanic.compat import Header
 from sanic.exceptions import (
     BadRequest,
+    BadURL,
     ExpectationFailed,
     PayloadTooLarge,
     RequestCancelled,
@@ -240,9 +241,14 @@ class Http(Stream, metaclass=TouchUpMeta):
             headers_instance.getone("upgrade", "").lower() == "websocket"
         )
 
+        try:
+            url_bytes = self.url.encode("ASCII")
+        except UnicodeEncodeError:
+            raise BadURL("URL may only contain US-ASCII characters.")
+
         # Prepare a Request object
         request = self.protocol.request_class(
-            url_bytes=self.url.encode(),
+            url_bytes=url_bytes,
             headers=headers_instance,
             head=bytes(head),
             version=protocol[5:],
@@ -443,9 +449,14 @@ class Http(Stream, metaclass=TouchUpMeta):
         bogus response for error handling use.
         """
 
+        # Reformat any URL already received with \xHH escapes for better logging
+        url_bytes = self.url.encode(errors="surrogateescape").decode(
+            "ASCII", errors="backslashreplace"
+        )
+
         # FIXME: Avoid this by refactoring error handling and response code
         self.request = self.protocol.request_class(
-            url_bytes=self.url.encode() if self.url else b"*",
+            url_bytes=url_bytes or b"*",
             headers=Header({}),
             version="1.1",
             method="NONE",

--- a/sanic/http/http3.py
+++ b/sanic/http/http3.py
@@ -18,7 +18,12 @@ from typing import (
 
 from sanic.compat import Header
 from sanic.constants import LocalCertCreator
-from sanic.exceptions import PayloadTooLarge, SanicException, ServerError
+from sanic.exceptions import (
+    BadURL,
+    PayloadTooLarge,
+    SanicException,
+    ServerError,
+)
 from sanic.helpers import has_message_body
 from sanic.http.constants import Stage
 from sanic.http.stream import Stream
@@ -333,7 +338,12 @@ class Http3:
         return self.receivers[stream_id]
 
     def _make_request(self, event: HeadersReceived) -> Request:
-        headers = Header(((k.decode(), v.decode()) for k, v in event.headers))
+        headers = Header(
+            (
+                (k.decode("ASCII"), v.decode(errors="surrogateescape"))
+                for k, v in event.headers
+            )
+        )
         method = headers[":method"]
         path = headers[":path"]
         scheme = headers.pop(":scheme", "")
@@ -342,9 +352,14 @@ class Http3:
         if authority:
             headers["host"] = authority
 
+        try:
+            url_bytes = path.encode("ASCII")
+        except UnicodeEncodeError:
+            raise BadURL("URL may only contain US-ASCII characters.")
+
         transport = HTTP3Transport(self.protocol)
         request = self.protocol.request_class(
-            path.encode(),
+            url_bytes,
             headers,
             "3",
             method,

--- a/sanic/request.py
+++ b/sanic/request.py
@@ -150,7 +150,8 @@ class Request:
         try:
             self._parsed_url = parse_url(url_bytes)
         except HttpParserInvalidURLError:
-            raise BadURL(f"Bad URL: {url_bytes.decode()}")
+            url = url_bytes.decode(errors="backslashreplace")
+            raise BadURL(f"Bad URL: {url}")
         self._id: Optional[Union[uuid.UUID, str, int]] = None
         self._name: Optional[str] = None
         self._stream_id = stream_id


### PR DESCRIPTION
- HTTP1 and HTTP3 built-in servers now enforce ASCII (%-quotes should be used for UTF-8).
- ASGI uses `raw_path` to avoid quote/encode cycle and unquoting of `%2F` into `/` early on.
- ASGI no longer prepends `root_path` to path used in Sanic.
- Using backslash escapes in logging and BadURL messages to print invalid characters.
