### PR TITLE
fix examples for freeze_support() issue on windows

### DIFF
--- a/examples/amending_request_object.py
+++ b/examples/amending_request_object.py
@@ -25,5 +25,5 @@ def key_exist_handler(request):
 
     return text("num does not exist in request")
 
-
-app.run(host="0.0.0.0", port=8000, debug=True)
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000, debug=True)

--- a/examples/blueprint_middlware_execution_order.py
+++ b/examples/blueprint_middlware_execution_order.py
@@ -50,4 +50,5 @@ def pop_handler(request):
 
 app.blueprint(bp, url_prefix="/bp")
 
-app.run(host="0.0.0.0", port=8000, debug=True, auto_reload=False)
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000, debug=True, auto_reload=False)

--- a/examples/blueprints.py
+++ b/examples/blueprints.py
@@ -37,4 +37,5 @@ app.blueprint(blueprint)
 app.blueprint(blueprint2)
 app.blueprint(blueprint3)
 
-app.run(host="0.0.0.0", port=9999, debug=True)
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=9999, debug=True)

--- a/examples/http_redirect.py
+++ b/examples/http_redirect.py
@@ -69,5 +69,5 @@ async def runner(app: Sanic, app_server: AsyncioServer):
         app.is_running = False
         app.is_stopping = True
 
-
-https.run(port=HTTPS_PORT, debug=True)
+if __name__ == "__main__":
+    https.run(port=HTTPS_PORT, debug=True)

--- a/examples/limit_concurrency.py
+++ b/examples/limit_concurrency.py
@@ -39,4 +39,5 @@ async def test(request):
         return json(response)
 
 
-app.run(host="0.0.0.0", port=8000, workers=2)
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000, workers=2)

--- a/examples/override_logging.py
+++ b/examples/override_logging.py
@@ -20,4 +20,5 @@ def test(request):
     return text("hey")
 
 
-app.run(host="0.0.0.0", port=8000)
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000)

--- a/examples/request_timeout.py
+++ b/examples/request_timeout.py
@@ -20,4 +20,5 @@ def timeout(request, exception):
     return response.text("RequestTimeout from error_handler.", 408)
 
 
-app.run(host="0.0.0.0", port=8000)
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000)

--- a/examples/run_async_advanced.py
+++ b/examples/run_async_advanced.py
@@ -35,34 +35,34 @@ async def after_server_stop(app, loop):
 async def test(request):
     return response.json({"answer": "42"})
 
+if __name__ == "__main__":
+    asyncio.set_event_loop(uvloop.new_event_loop())
+    serv_coro = app.create_server(
+        host="0.0.0.0", port=8000, return_asyncio_server=True
+    )
+    loop = asyncio.get_event_loop()
+    serv_task = asyncio.ensure_future(serv_coro, loop=loop)
+    signal(SIGINT, lambda s, f: loop.stop())
+    server: AsyncioServer = loop.run_until_complete(serv_task)
+    loop.run_until_complete(server.startup())
 
-asyncio.set_event_loop(uvloop.new_event_loop())
-serv_coro = app.create_server(
-    host="0.0.0.0", port=8000, return_asyncio_server=True
-)
-loop = asyncio.get_event_loop()
-serv_task = asyncio.ensure_future(serv_coro, loop=loop)
-signal(SIGINT, lambda s, f: loop.stop())
-server: AsyncioServer = loop.run_until_complete(serv_task)
-loop.run_until_complete(server.startup())
+    # When using app.run(), this actually triggers before the serv_coro.
+    # But, in this example, we are using the convenience method, even if it is
+    # out of order.
+    loop.run_until_complete(server.before_start())
+    loop.run_until_complete(server.after_start())
+    try:
+        loop.run_forever()
+    except KeyboardInterrupt:
+        loop.stop()
+    finally:
+        loop.run_until_complete(server.before_stop())
 
-# When using app.run(), this actually triggers before the serv_coro.
-# But, in this example, we are using the convenience method, even if it is
-# out of order.
-loop.run_until_complete(server.before_start())
-loop.run_until_complete(server.after_start())
-try:
-    loop.run_forever()
-except KeyboardInterrupt:
-    loop.stop()
-finally:
-    loop.run_until_complete(server.before_stop())
+        # Wait for server to close
+        close_task = server.close()
+        loop.run_until_complete(close_task)
 
-    # Wait for server to close
-    close_task = server.close()
-    loop.run_until_complete(close_task)
-
-    # Complete all tasks on the loop
-    for connection in server.connections:
-        connection.close_if_idle()
-    loop.run_until_complete(server.after_stop())
+        # Complete all tasks on the loop
+        for connection in server.connections:
+            connection.close_if_idle()
+        loop.run_until_complete(server.after_stop())


### PR DESCRIPTION
Sanic on windows should always run inside:

`if __name__ == "__main__": app.run()`

Check this: https://docs.python.org/2/library/multiprocessing.html#the-process-class

`For an explanation of why (on Windows) the if __name__ == '__main__' part is necessary, see` [[Programming guidelines]](https://docs.python.org/2/library/multiprocessing.html#multiprocessing-programming)

Without the `__name__ == "__main__"` it throw this error on windows:

```
RuntimeError:
        An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.

        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:

            if __name__ == '__main__':
                freeze_support()
                ...

        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.
```

On Linux, Mac it's run normally.
I think we should update the docs to notify the users about this issue.