### PR TITLE
sanic/app: When streaming, check REQUEST_MAX_SIZE if length is known

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -57,6 +57,7 @@ from sanic.compat import OS_IS_WINDOWS, enable_windows_color_support
 from sanic.config import SANIC_PREFIX, Config
 from sanic.exceptions import (
     BadRequest,
+    PayloadTooLarge,
     SanicException,
     ServerError,
     URLBuildError,
@@ -933,9 +934,11 @@ class Sanic(StaticHandleMixin, BaseSanic, StartupMixin, metaclass=TouchUpMeta):
                 and request.stream.request_body
                 and not route.extra.ignore_body
             ):
+
                 if hasattr(handler, "is_stream"):
-                    # Streaming handler: lift the size limit
-                    request.stream.request_max_size = float("inf")
+                    rq_len = request.stream.request_bytes
+                    if rq_len and rq_len > request.stream.request_max_size:
+                        raise PayloadTooLarge("Request body exceeds the size limit")
                 else:
                     # Non-streaming handler: preload body
                     await request.receive_body()


### PR DESCRIPTION
Following the [discussion](https://community.sanicframework.org/t/streaming-handling-improvements/1192), this PR adds a check for the streaming case to early quit request processing in case request has a content length larger than the `REQUEST_MAX_SIZE`. Tested locally and it seems to work.