### PR TITLE
Add convenience method for exception reporting

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -613,7 +613,7 @@ class Sanic(
             await handler(self, exception)
 
         self.add_signal(
-            handler=report, event=Event.SERVER_GLOBAL_EXCEPTION.value
+            handler=report, event=Event.SERVER_EXCEPTION_REPORT.value
         )
 
         return report
@@ -890,7 +890,7 @@ class Sanic(
         """
         response = None
         await self.dispatch(
-            "server.lifecycle.exception",
+            "server.exception.report",
             context={"exception": exception},
         )
         await self.dispatch(

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -890,6 +890,7 @@ class Sanic(
         """
         response = None
         if not getattr(exception, "__dispatched__", False):
+            ...  # DO NOT REMOVE THIS LINE. IT IS NEEDED FOR TOUCHUP.
             await self.dispatch(
                 "server.exception.report",
                 context={"exception": exception},

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -613,7 +613,7 @@ class Sanic(
             await handler(self, exception)
 
         self.add_signal(
-            handler=report, event=Event.SERVER_LIFECYCLE_EXCEPTION.value
+            handler=report, event=Event.SERVER_GLOBAL_EXCEPTION.value
         )
 
         return report

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -889,7 +889,6 @@ class Sanic(
         :raises ServerError: response 500
         """
         response = None
-        print(">>>>")
         if not getattr(exception, "__dispatched__", False):
             await self.dispatch(
                 "server.exception.report",

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -1338,6 +1338,7 @@ class Sanic(
                 error_logger.warning(
                     f"Task {task} was cancelled before it completed."
                 )
+                raise
             except Exception as e:
                 await app.dispatch(
                     "server.exception.report",

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -612,7 +612,9 @@ class Sanic(
         async def report(exception: Exception) -> None:
             await handler(self, exception)
 
-        self.add_signal(handler=report, event=Event.SERVER_LIFECYCLE_EXCEPTION)
+        self.add_signal(
+            handler=report, event=Event.SERVER_LIFECYCLE_EXCEPTION.value
+        )
 
         return report
 

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -889,10 +889,12 @@ class Sanic(
         :raises ServerError: response 500
         """
         response = None
-        await self.dispatch(
-            "server.exception.report",
-            context={"exception": exception},
-        )
+        print(">>>>")
+        if not getattr(exception, "__dispatched__", False):
+            await self.dispatch(
+                "server.exception.report",
+                context={"exception": exception},
+            )
         await self.dispatch(
             "http.lifecycle.exception",
             inline=True,

--- a/sanic/signals.py
+++ b/sanic/signals.py
@@ -16,7 +16,7 @@ from sanic.models.handler_types import SignalHandler
 
 
 class Event(Enum):
-    SERVER_GLOBAL_EXCEPTION = "server.global.exception"
+    SERVER_EXCEPTION_REPORT = "server.exception.report"
     SERVER_INIT_AFTER = "server.init.after"
     SERVER_INIT_BEFORE = "server.init.before"
     SERVER_SHUTDOWN_AFTER = "server.shutdown.after"
@@ -40,7 +40,7 @@ class Event(Enum):
 
 RESERVED_NAMESPACES = {
     "server": (
-        Event.SERVER_GLOBAL_EXCEPTION.value,
+        Event.SERVER_EXCEPTION_REPORT.value,
         Event.SERVER_INIT_AFTER.value,
         Event.SERVER_INIT_BEFORE.value,
         Event.SERVER_SHUTDOWN_AFTER.value,
@@ -174,9 +174,9 @@ class SignalRouter(BaseRouter):
             if self.ctx.app.debug and self.ctx.app.state.verbosity >= 1:
                 error_logger.exception(e)
 
-            if event != Event.SERVER_GLOBAL_EXCEPTION.value:
+            if event != Event.SERVER_EXCEPTION_REPORT.value:
                 await self.dispatch(
-                    Event.SERVER_GLOBAL_EXCEPTION.value,
+                    Event.SERVER_EXCEPTION_REPORT.value,
                     context={"exception": e},
                 )
             raise e

--- a/sanic/signals.py
+++ b/sanic/signals.py
@@ -20,7 +20,7 @@ class Event(Enum):
     SERVER_INIT_BEFORE = "server.init.before"
     SERVER_SHUTDOWN_AFTER = "server.shutdown.after"
     SERVER_SHUTDOWN_BEFORE = "server.shutdown.before"
-    SERVER_LIFECYCLE_EXCEPTION = "server.lifecycle.exception"
+    SERVER_GLOBAL_EXCEPTION = "server.lifecycle.exception"
     HTTP_LIFECYCLE_BEGIN = "http.lifecycle.begin"
     HTTP_LIFECYCLE_COMPLETE = "http.lifecycle.complete"
     HTTP_LIFECYCLE_EXCEPTION = "http.lifecycle.exception"
@@ -44,7 +44,7 @@ RESERVED_NAMESPACES = {
         Event.SERVER_INIT_BEFORE.value,
         Event.SERVER_SHUTDOWN_AFTER.value,
         Event.SERVER_SHUTDOWN_BEFORE.value,
-        Event.SERVER_LIFECYCLE_EXCEPTION.value,
+        Event.SERVER_GLOBAL_EXCEPTION.value,
     ),
     "http": (
         Event.HTTP_LIFECYCLE_BEGIN.value,
@@ -174,9 +174,9 @@ class SignalRouter(BaseRouter):
             if self.ctx.app.debug and self.ctx.app.state.verbosity >= 1:
                 error_logger.exception(e)
 
-            if event != Event.SERVER_LIFECYCLE_EXCEPTION.value:
+            if event != Event.SERVER_GLOBAL_EXCEPTION.value:
                 await self.dispatch(
-                    Event.SERVER_LIFECYCLE_EXCEPTION.value,
+                    Event.SERVER_GLOBAL_EXCEPTION.value,
                     context={"exception": e},
                 )
             raise e

--- a/sanic/signals.py
+++ b/sanic/signals.py
@@ -179,6 +179,7 @@ class SignalRouter(BaseRouter):
                     Event.SERVER_EXCEPTION_REPORT.value,
                     context={"exception": e},
                 )
+                e.__dispatched__ = True
             raise e
         finally:
             for signal_event in events:

--- a/sanic/signals.py
+++ b/sanic/signals.py
@@ -179,7 +179,7 @@ class SignalRouter(BaseRouter):
                     Event.SERVER_EXCEPTION_REPORT.value,
                     context={"exception": e},
                 )
-                e.__dispatched__ = True
+                setattr(e, "__dispatched__", True)
             raise e
         finally:
             for signal_event in events:

--- a/sanic/signals.py
+++ b/sanic/signals.py
@@ -16,11 +16,11 @@ from sanic.models.handler_types import SignalHandler
 
 
 class Event(Enum):
+    SERVER_GLOBAL_EXCEPTION = "server.global.exception"
     SERVER_INIT_AFTER = "server.init.after"
     SERVER_INIT_BEFORE = "server.init.before"
     SERVER_SHUTDOWN_AFTER = "server.shutdown.after"
     SERVER_SHUTDOWN_BEFORE = "server.shutdown.before"
-    SERVER_GLOBAL_EXCEPTION = "server.lifecycle.exception"
     HTTP_LIFECYCLE_BEGIN = "http.lifecycle.begin"
     HTTP_LIFECYCLE_COMPLETE = "http.lifecycle.complete"
     HTTP_LIFECYCLE_EXCEPTION = "http.lifecycle.exception"
@@ -40,11 +40,11 @@ class Event(Enum):
 
 RESERVED_NAMESPACES = {
     "server": (
+        Event.SERVER_GLOBAL_EXCEPTION.value,
         Event.SERVER_INIT_AFTER.value,
         Event.SERVER_INIT_BEFORE.value,
         Event.SERVER_SHUTDOWN_AFTER.value,
         Event.SERVER_SHUTDOWN_BEFORE.value,
-        Event.SERVER_GLOBAL_EXCEPTION.value,
     ),
     "http": (
         Event.HTTP_LIFECYCLE_BEGIN.value,

--- a/tests/test_signal_handlers.py
+++ b/tests/test_signal_handlers.py
@@ -160,7 +160,7 @@ def test_signal_server_lifecycle_exception(app: Sanic):
     async def hello_route(request):
         return HTTPResponse()
 
-    @app.signal(Event.SERVER_LIFECYCLE_EXCEPTION)
+    @app.signal(Event.SERVER_GLOBAL_EXCEPTION)
     async def test_signal(exception: Exception):
         nonlocal trigger
         trigger = exception

--- a/tests/test_signal_handlers.py
+++ b/tests/test_signal_handlers.py
@@ -160,7 +160,7 @@ def test_signal_server_lifecycle_exception(app: Sanic):
     async def hello_route(request):
         return HTTPResponse()
 
-    @app.signal(Event.SERVER_GLOBAL_EXCEPTION)
+    @app.signal(Event.SERVER_EXCEPTION_REPORT)
     async def test_signal(exception: Exception):
         nonlocal trigger
         trigger = exception

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -445,7 +445,7 @@ async def test_report_exception(app: Sanic):
     registered_signal_handlers = [
         handler
         for handler, *_ in app.signal_router.get(
-            Event.SERVER_LIFECYCLE_EXCEPTION.value
+            Event.SERVER_GLOBAL_EXCEPTION.value
         )
     ]
 

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -445,7 +445,7 @@ async def test_report_exception(app: Sanic):
     registered_signal_handlers = [
         handler
         for handler, *_ in app.signal_router.get(
-            Event.SERVER_GLOBAL_EXCEPTION.value
+            Event.SERVER_EXCEPTION_REPORT.value
         )
     ]
 

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -2,6 +2,7 @@ import asyncio
 
 from enum import Enum
 from inspect import isawaitable
+from itertools import count
 
 import pytest
 
@@ -466,3 +467,76 @@ def test_report_exception_runs(app: Sanic):
     app.test_client.get("/")
 
     assert event.is_set()
+
+
+def test_report_exception_runs_once_inline(app: Sanic):
+    event = asyncio.Event()
+    c = count()
+
+    @app.report_exception
+    async def catch_any_exception(app: Sanic, exception: Exception):
+        event.set()
+        next(c)
+
+    @app.route("/")
+    async def handler(request):
+        ...
+
+    @app.signal(Event.HTTP_ROUTING_AFTER.value)
+    async def after_routing(**_):
+        1 / 0
+
+    app.test_client.get("/")
+
+    assert event.is_set()
+    assert next(c) == 1
+
+
+def test_report_exception_runs_once_custom(app: Sanic):
+    event = asyncio.Event()
+    c = count()
+
+    @app.report_exception
+    async def catch_any_exception(app: Sanic, exception: Exception):
+        event.set()
+        next(c)
+
+    @app.route("/")
+    async def handler(request):
+        await app.dispatch("one.two.three")
+        return empty()
+
+    @app.signal("one.two.three")
+    async def one_two_three(**_):
+        1 / 0
+
+    app.test_client.get("/")
+
+    assert event.is_set()
+    assert next(c) == 1
+
+
+def test_report_exception_runs_task(app: Sanic):
+    c = count()
+
+    async def task_1():
+        next(c)
+
+    async def task_2(app):
+        next(c)
+
+    @app.report_exception
+    async def catch_any_exception(app: Sanic, exception: Exception):
+        next(c)
+
+    @app.route("/")
+    async def handler(request):
+        app.add_task(task_1)
+        app.add_task(task_1())
+        app.add_task(task_2)
+        app.add_task(task_2(app))
+        return empty()
+
+    app.test_client.get("/")
+
+    assert next(c) == 4


### PR DESCRIPTION
#2724 adds a new signal to trigger on all exceptions: `"server.lifecycle.exception"`

This PR adds a convenience for setting up a task for capturing this signal to do something with it. The obvious use case is for error reporting that does not need to be in the way of returning a response.

```python
@app.report_exception
async def catch_any_exception(app: Sanic, exception: Exception):
    print("Caught exception:", exception)
```

Also, since it is still an unreleased signal, this PR renames it to `"server.exception.report"`, which is I think is a less confusing name since it is not strictly tied to server lifecycle.

Lastly, in exploring this earlier PR, I realized that there was a bug (double dispatch on some built-in signals that happened inline in a request), and I also realized that we were not capturing exceptions in background tasks. This PR handles these scenarios as well.