### PR TITLE
Refactoring unit test cases

### DIFF
--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -20,6 +20,7 @@ from pytest import LogCaptureFixture
 
 from sanic import Request, Sanic
 from sanic.compat import Header
+from sanic.constants import DEFAULT_HTTP_CONTENT_TYPE
 from sanic.cookies import CookieJar
 from sanic.response import (
     HTTPResponse,
@@ -545,7 +546,7 @@ def test_raw_response(app):
         return raw(b"raw_response")
 
     request, response = app.test_client.get("/test")
-    assert response.content_type == "application/octet-stream"
+    assert response.content_type == DEFAULT_HTTP_CONTENT_TYPE
     assert response.body == b"raw_response"
 
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -502,7 +502,7 @@ def test_dynamic_route_int(app):
 
     request, response = app.test_client.get("/folder/12345")
     assert response.text == "OK"
-    assert type(results[0]) is int
+    assert isinstance(results[0], int)
 
     request, response = app.test_client.get("/folder/asdf")
     assert response.status == 404
@@ -518,7 +518,7 @@ def test_dynamic_route_number(app):
 
     request, response = app.test_client.get("/weight/12345")
     assert response.text == "OK"
-    assert type(results[0]) is float
+    assert isinstance(results[0], float)
 
     request, response = app.test_client.get("/weight/1234.56")
     assert response.status == 200
@@ -567,7 +567,7 @@ def test_dynamic_route_uuid(app):
     url = "/quirky/123e4567-e89b-12d3-a456-426655440000"
     request, response = app.test_client.get(url)
     assert response.text == "OK"
-    assert type(results[0]) is uuid.UUID
+    assert isinstance(results[0], uuid.UUID)
 
     generated_uuid = uuid.uuid4()
     request, response = app.test_client.get(f"/quirky/{generated_uuid}")
@@ -861,7 +861,7 @@ def test_dynamic_add_route_int(app):
 
     request, response = app.test_client.get("/folder/12345")
     assert response.text == "OK"
-    assert type(results[0]) is int
+    assert isinstance(results[0], int)
 
     request, response = app.test_client.get("/folder/asdf")
     assert response.status == 404
@@ -878,7 +878,7 @@ def test_dynamic_add_route_number(app):
 
     request, response = app.test_client.get("/weight/12345")
     assert response.text == "OK"
-    assert type(results[0]) is float
+    assert isinstance(results[0], float)
 
     request, response = app.test_client.get("/weight/1234.56")
     assert response.status == 200


### PR DESCRIPTION
Hello, first-time submitting PR here. 

This PR improves the readability of the assert statements in the unit tests. These changes improve code quality (avoid test smells) by:

- Using isinstance() is the more Pythonic way to check types, as it supports polymorphism, and also consistent with other test files within the project.

- Simplifying code management. For example, instead of simply saying "application/octet-stream", use the parameter name(DEFAULT_HTTP_CONTENT_TYPE) so that developers could only update the value in one place.


Happy to update more related issues in the test code if needed :)