### PR TITLE
Fix Docker image publish GitHub Action

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -2,7 +2,7 @@ name: Publish Docker Images
 on:
   workflow_run:
     workflows:
-      - 'Publish Artifacts'
+      - 'Upload Python Package'
     types:
       - completed
 


### PR DESCRIPTION
It stopped working in the last release due to [the name change of PyPI publish action](https://github.com/sanic-org/sanic/pull/2797/files#diff-76272691d414169ea851c113f750e3f9638354d7e4473ad7131d69ec1fcea201L1).