### PR TITLE
Add constraint for autodocsumm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -143,6 +143,7 @@ docs_require = [
     "m2r2",
     "enum-tools[sphinx]",
     "mistune<2.0.0",
+    "autodocsumm>=0.2.11",
 ]
 
 dev_require = tests_require + [


### PR DESCRIPTION
Fixes the lint failure when encountering a bad version constraint in an old package version