### PR TITLE
Run tests on push as well

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,13 @@
 name: Tests
 
 on:
+  push:
+    branches:
+      - main
+      - current-release
+      - "*LTS"
+    tags:
+      - "!*"
   pull_request:
     branches:
       - main


### PR DESCRIPTION
We should run tests on push as well because PRs don't always have the latest changes in `main`.

This will also make the "tests" status badge in the readme work.