### PR TITLE
Allow range requests for a single byte

### DIFF
--- a/sanic/handlers/content_range.py
+++ b/sanic/handlers/content_range.py
@@ -62,7 +62,7 @@ class ContentRangeHandler(Range):
                 # this case represents `Content-Range: bytes -5`
                 self.start = self.total - self.end
                 self.end = self.total - 1
-        if self.start >= self.end:
+        if self.start > self.end:
             raise RangeNotSatisfiable(
                 "Invalid for Content Range parameters", self
             )


### PR DESCRIPTION
It is OK to ask for one byte (end is inclusive). Apparently Chrome keeps doing this quite often.