### PR TITLE
Make request.scheme return ws/wss for SERVER_NAME or proxied proto http/https.

### DIFF
--- a/tests/test_ws_handlers.py
+++ b/tests/test_ws_handlers.py
@@ -7,9 +7,7 @@ from websockets.client import WebSocketClientProtocol
 from sanic import Request, Sanic, Websocket
 
 
-MimicClientType = Callable[
-    [WebSocketClientProtocol], Coroutine[None, None, Any]
-]
+MimicClientType = Callable[[WebSocketClientProtocol], Coroutine[None, None, Any]]
 
 
 @pytest.fixture
@@ -33,9 +31,7 @@ def test_ws_handler(
             msg = await ws.recv()
             await ws.send(msg)
 
-    _, ws_proxy = app.test_client.websocket(
-        "/ws", mimic=simple_ws_mimic_client
-    )
+    _, ws_proxy = app.test_client.websocket("/ws", mimic=simple_ws_mimic_client)
     assert ws_proxy.client_sent == ["test 1", "test 2", ""]
     assert ws_proxy.client_received == ["test 1", "test 2"]
 
@@ -49,8 +45,39 @@ def test_ws_handler_async_for(
         async for msg in ws:
             await ws.send(msg)
 
-    _, ws_proxy = app.test_client.websocket(
-        "/ws", mimic=simple_ws_mimic_client
-    )
+    _, ws_proxy = app.test_client.websocket("/ws", mimic=simple_ws_mimic_client)
     assert ws_proxy.client_sent == ["test 1", "test 2", ""]
     assert ws_proxy.client_received == ["test 1", "test 2"]
+
+
+def test_request_url(
+    app: Sanic,
+    simple_ws_mimic_client: MimicClientType,
+):
+    @app.websocket("/ws")
+    async def ws_url_handler(request: Request, ws: Websocket):
+        request.headers[
+            "forwarded"
+        ] = "for=[2001:db8::1];proto=https;host=example.com;by=proxy"
+
+        await ws.recv()
+        await ws.send(request.url)
+        await ws.recv()
+        await ws.send(request.url_for("ws_url_handler"))
+        await ws.recv()
+
+    for proxy in ["", "proxy"]:
+        app.config.FORWARDED_SECRET = proxy
+
+        _, ws_proxy = app.test_client.websocket(
+            "/ws",
+            mimic=simple_ws_mimic_client,
+        )
+        assert ws_proxy.client_sent == ["test 1", "test 2", ""]
+        assert ws_proxy.client_received[0] == ws_proxy.client_received[1]
+        if proxy:
+            assert ws_proxy.client_received[0] == "wss://example.com/ws"
+            assert ws_proxy.client_received[1] == "wss://example.com/ws"
+        else:
+            assert ws_proxy.client_received[0].startswith("ws://127.0.0.1")
+            assert ws_proxy.client_received[1].startswith("ws://127.0.0.1")


### PR DESCRIPTION
Previously it would work as expected locally, but if the scheme was sourced from full URL SERVER_NAME or proxied forwarded headers, incorrect URLs were returned.
