### PR TITLE
Convert Sanic `Request` to WebSocket `Request` in `websocket_handshake`

### DIFF
--- a/sanic/server/protocols/websocket_protocol.py
+++ b/sanic/server/protocols/websocket_protocol.py
@@ -9,6 +9,7 @@ except ImportError:  # websockets >= 11.0
     from websockets.server import ServerProtocol  # type: ignore
 
 from websockets import http11
+from websockets.datastructures import Headers as WSHeaders
 from websockets.typing import Subprotocol
 
 from sanic.exceptions import SanicException
@@ -96,7 +97,7 @@ class WebSocketProtocol(HttpProtocol):
     def sanic_request_to_ws_request(request: Request):
         return http11.Request(
             path=request.path,
-            headers=request.headers,
+            headers=WSHeaders(request.headers),
         )
 
     async def websocket_handshake(

--- a/sanic/server/protocols/websocket_protocol.py
+++ b/sanic/server/protocols/websocket_protocol.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, Sequence, cast
+from typing import Optional, Sequence, cast
 
 
 try:  # websockets < 11.0

--- a/sanic/server/protocols/websocket_protocol.py
+++ b/sanic/server/protocols/websocket_protocol.py
@@ -123,9 +123,7 @@ class WebSocketProtocol(HttpProtocol):
                 state=OPEN,
                 logger=logger,
             )
-            resp = ws_proto.accept(
-                self.sanic_request_to_ws_request(request)
-            )
+            resp = ws_proto.accept(self.sanic_request_to_ws_request(request))
         except Exception:
             msg = (
                 "Failed to open a WebSocket connection.\n"

--- a/sanic/server/protocols/websocket_protocol.py
+++ b/sanic/server/protocols/websocket_protocol.py
@@ -123,7 +123,7 @@ class WebSocketProtocol(HttpProtocol):
                 state=OPEN,
                 logger=logger,
             )
-            resp: "http11.Response" = ws_proto.accept(
+            resp = ws_proto.accept(
                 self.sanic_request_to_ws_request(request)
             )
         except Exception:

--- a/sanic/server/protocols/websocket_protocol.py
+++ b/sanic/server/protocols/websocket_protocol.py
@@ -8,17 +8,15 @@ except ImportError:  # websockets >= 11.0
     from websockets.protocol import State  # type: ignore
     from websockets.server import ServerProtocol  # type: ignore
 
+from websockets import http11
 from websockets.typing import Subprotocol
 
 from sanic.exceptions import SanicException
 from sanic.log import logger
+from sanic.request import Request
 from sanic.server import HttpProtocol
 
 from ..websockets.impl import WebsocketImplProtocol
-
-
-if TYPE_CHECKING:
-    from websockets import http11
 
 
 OPEN = State.OPEN
@@ -94,6 +92,13 @@ class WebSocketProtocol(HttpProtocol):
         else:
             return super().close_if_idle()
 
+    @staticmethod
+    def sanic_request_to_ws_request(request: Request):
+        return http11.Request(
+            path=request.path,
+            headers=request.headers,
+        )
+
     async def websocket_handshake(
         self, request, subprotocols: Optional[Sequence[str]] = None
     ):
@@ -117,7 +122,9 @@ class WebSocketProtocol(HttpProtocol):
                 state=OPEN,
                 logger=logger,
             )
-            resp: "http11.Response" = ws_proto.accept(request)
+            resp: "http11.Response" = ws_proto.accept(
+                self.sanic_request_to_ws_request(request)
+            )
         except Exception:
             msg = (
                 "Failed to open a WebSocket connection.\n"

--- a/tests/test_ws_handlers.py
+++ b/tests/test_ws_handlers.py
@@ -1,3 +1,6 @@
+import base64
+import secrets
+
 from typing import Any, Callable, Coroutine
 
 import pytest
@@ -68,6 +71,23 @@ def test_ws_handler(
     _, ws_proxy = app.test_client.websocket("/ws", mimic=simple_ws_mimic_client)
     assert ws_proxy.client_sent == ["test 1", "test 2", ""]
     assert ws_proxy.client_received == ["test 1", "test 2"]
+
+
+def test_ws_handler_invalid_upgrade(app: Sanic):
+    @app.websocket("/ws")
+    async def ws_echo_handler(request: Request, ws: Websocket):
+        async for msg in ws:
+            await ws.send(msg)
+
+    ws_key = base64.b64encode(secrets.token_bytes(16)).decode("utf-8")
+    invalid_upgrade_headers = {
+        "Upgrade": "websocket",
+        # "Connection": "Upgrade",
+        "Sec-WebSocket-Key": ws_key,
+        "Sec-WebSocket-Version": "13",
+    }
+    _, response = app.test_client.get("/ws", headers=invalid_upgrade_headers)
+    assert response.status == 426
 
 
 def test_ws_handler_async_for(


### PR DESCRIPTION
### Description

This PR is a (potentially naive) solution to fix an issue that missed WebSocket Upgrade request header during a WebSocket handshaking process causing 500 server error being returned.

After debugging, I found that the error stems from Sanic's Request object being passed into `ws_proto.accept(...)` method, which expects a `request` to be a [WebSocket Request object](https://github.com/python-websockets/websockets/blob/5737b474ad7d4a3a5e04d68299f4e5ec34bd62ac/src/websockets/http11.py#L52). The issue is occurred when the `websockets` package is trying to assign an `_exception` value to the request object, resulting the attribute not existent error will be raised, which causes a 500 server error.

My solution is to convert Sanic Request object to be a WebSocket Request object in `websocket_handshake` method. I feel like this is a naive solution and am stilling digging into how a WebSocket requests is processed in Sanic's code, and I am also working on test cases.

May I have some feedback and comments?

### Related issue

closes #2743 

### Code snippets for reproducing the issue

#### server

```python
import sanic

from sanic import Request
from sanic.server.websockets.impl import WebsocketImplProtocol

app = sanic.Sanic("MySanic")

@app.websocket("/ws-echo")
async def ws_echo(request: Request, ws: WebsocketImplProtocol):
    message = "Start"
    while True:
        await ws.send(message)
        message = await ws.recv()


if __name__ == "__main__":
    app.run(auto_reload=True)
```

#### client

```python
import http.client
import base64
import secrets
from urllib.parse import urlparse


def connect_websocket(url: str, message: str) -> None:
    parsed_url = urlparse(url)
    conn = http.client.HTTPConnection(parsed_url.netloc)

    websocket_key = base64.b64encode(secrets.token_bytes(16)).decode('utf-8')
    headers = {
        "Upgrade": "websocket",
        #"Connection": "Upgrade",
        "Sec-WebSocket-Key": websocket_key,
        "Sec-WebSocket-Version": "13"
    }

    conn.putrequest("GET", parsed_url.path)
    for header, value in headers.items():
        conn.putheader(header, value)
    conn.endheaders()

    response = conn.getresponse()
    if response.status == 101 and response.getheader('Upgrade', '').lower() == 'websocket':
        print("WebSocket handshake successful")
        conn.sock.sendall(message.encode())
    else:
        print(f"WebSocket handshake failed: {response.status} {response.reason}")

    conn.close()

websocket_url = "ws://localhost:8000/ws-echo"
connect_websocket(websocket_url, "Hello, WebSocket Server!")

```