### PR TITLE
issue:2832 Adjust documentation for using  state properties within http -> https redirects doc.

### DIFF
--- a/guide/content/en/guide/how-to/tls.md
+++ b/guide/content/en/guide/how-to/tls.md
@@ -156,15 +156,15 @@ async def stop(app, _):
     await app.ctx.redirect.close()
 
 async def runner(app, app_server):
-    app.is_running = True
+    app.state.is_running = True
     try:
         app.signalize()
         app.finalize()
         app.state.is_started = True
         await app_server.serve_forever()
     finally:
-        app.is_running = False
-        app.is_stopping = True
+        app.state.is_running = False
+        app.state.is_stopping = True
 ```
 
 ## Get certificates for your domain names


### PR DESCRIPTION
This comes from a request to adjust documentation related to the http -> httpx redirects.
Issue link: https://github.com/sanic-org/sanic/issues/2832

Please note that `signalize` and `finalize` usage hasn't been adjusted, since more details needed to confirm that errors come from the sanic library and not related to local user setup.