### PR TITLE
Add ruff to toolchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,6 @@ help:
 	@echo "pretty"
 	@echo "		Analyze and fix linting and format using ruff"
 	@echo ""
-	@echo "beautify [sort_imports=1] [include_tests=1]"
-	@echo "		Analyze and fix linting issue using black and optionally fix import sort using isort"
-	@echo ""
 	@echo "docs"
 	@echo "		Generate Sanic documentation"
 	@echo ""
@@ -55,11 +52,11 @@ docker-test: clean
 	docker run -t sanic/test-image tox
 
 .PHONY: fix
-black:
+fix:
 	ruff check sanic --fix
 
 .PHONY: format
-isort:
+format:
 	ruff format sanic
 
 .PHONY: pretty

--- a/Makefile
+++ b/Makefile
@@ -7,12 +7,12 @@ help:
 	@echo "		Install Sanic"
 	@echo "docker-test"
 	@echo "		Run Sanic Unit Tests using Docker"
-	@echo "black"
-	@echo "		Analyze and fix linting issues using Black"
-	@echo "isort"
-	@echo "		Analyze and fix import order using isort"
+	@echo "fix"
+	@echo "		Analyze and fix linting issues using ruff"
+	@echo "format"
+	@echo "		Analyze and format using ruff"
 	@echo "pretty"
-	@echo "		Analyze and fix linting issue using black and isort"
+	@echo "		Analyze and fix linting and format using ruff"
 	@echo ""
 	@echo "beautify [sort_imports=1] [include_tests=1]"
 	@echo "		Analyze and fix linting issue using black and optionally fix import sort using isort"
@@ -54,28 +54,16 @@ docker-test: clean
 	docker build -t sanic/test-image -f docker/Dockerfile .
 	docker run -t sanic/test-image tox
 
-.PHONY: beautify
-beautify: black
-ifdef sort_imports
-ifdef include_tests
-	$(warning It is suggested that you do not run sort import on tests)
-	isort -rc sanic tests
-else
-	$(info Sorting Imports)
-	isort -rc sanic tests
-endif
-endif
-
-.PHONY: black
+.PHONY: fix
 black:
-	black sanic tests
+	ruff check sanic --fix
 
-.PHONY: isort
+.PHONY: format
 isort:
-	isort sanic tests
+	ruff format sanic
 
 .PHONY: pretty
-pretty: black isort
+pretty: fix format
 
 .PHONY: docs-clean
 docs-clean:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,20 +2,36 @@
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.black]
+
+[tool.ruff]
+target-version = "py38"
 line-length = 79
 
-[tool.isort]
-atomic = true
-default_section = "THIRDPARTY"
-include_trailing_comma = true
-known_first_party = "sanic"
-known_third_party = "pytest"
-line_length = 79
-lines_after_imports = 2
-lines_between_types = 1
-multi_line_output = 3
-profile = "black"
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle
+    "F",    # pyflakes
+    "I",    # isort
+    "W",    # pycodestyle warnings
+]
+ignore = [
+    "E203",
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+
+[tool.ruff.isort]
+known-first-party = ["sanic"]
+known-third-party = ["pytest"]
+lines-after-imports = 2
+lines-between-types = 1
 
 [[tool.mypy.overrides]]
 module = [

--- a/sanic/headers.py
+++ b/sanic/headers.py
@@ -349,8 +349,7 @@ def parse_content_header(value: str) -> Tuple[str, Options]:
         options: Dict[str, Union[int, str]] = {}
     else:
         options = {
-            m.group(1)
-            .lower(): (m.group(2) or m.group(3))
+            m.group(1).lower(): (m.group(2) or m.group(3))
             .replace("%22", '"')
             .replace("%0D%0A", "\n")
             for m in _param.finditer(value[pos:])

--- a/sanic/mixins/exceptions.py
+++ b/sanic/mixins/exceptions.py
@@ -14,7 +14,7 @@ class ExceptionMixin(metaclass=SanicMeta):
     def exception(
         self,
         *exceptions: Union[Type[Exception], List[Type[Exception]]],
-        apply: bool = True
+        apply: bool = True,
     ) -> Callable:
         """Decorator used to register an exception handler for the current application or blueprint instance.
 

--- a/sanic/mixins/middleware.py
+++ b/sanic/mixins/middleware.py
@@ -25,7 +25,7 @@ class MiddlewareMixin(metaclass=SanicMeta):
         attach_to: str = "request",
         apply: bool = True,
         *,
-        priority: int = 0
+        priority: int = 0,
     ) -> MiddlewareType:
         ...
 
@@ -36,7 +36,7 @@ class MiddlewareMixin(metaclass=SanicMeta):
         attach_to: str = "request",
         apply: bool = True,
         *,
-        priority: int = 0
+        priority: int = 0,
     ) -> Callable[[MiddlewareType], MiddlewareType]:
         ...
 
@@ -46,7 +46,7 @@ class MiddlewareMixin(metaclass=SanicMeta):
         attach_to: str = "request",
         apply: bool = True,
         *,
-        priority: int = 0
+        priority: int = 0,
     ) -> Union[MiddlewareType, Callable[[MiddlewareType], MiddlewareType]]:
         """Decorator for registering middleware.
 

--- a/sanic/models/server_types.py
+++ b/sanic/models/server_types.py
@@ -44,12 +44,8 @@ class ConnInfo:
         self.server_name = ""
         self.cert: Dict[str, Any] = {}
         self.network_paths: List[Any] = []
-        sslobj: Optional[SSLObject] = transport.get_extra_info(
-            "ssl_object"
-        )  # type: ignore
-        sslctx: Optional[SSLContext] = transport.get_extra_info(
-            "ssl_context"
-        )  # type: ignore
+        sslobj: Optional[SSLObject] = transport.get_extra_info("ssl_object")  # type: ignore
+        sslctx: Optional[SSLContext] = transport.get_extra_info("ssl_context")  # type: ignore
         if sslobj:
             self.ssl = True
             self.server_name = getattr(sslobj, "sanic_server_name", None) or ""

--- a/sanic/server/websockets/frame.py
+++ b/sanic/server/websockets/frame.py
@@ -57,9 +57,7 @@ class WebsocketFrameAssembler:
         self.read_mutex = asyncio.Lock()
         self.write_mutex = asyncio.Lock()
 
-        self.completed_queue = asyncio.Queue(
-            maxsize=1
-        )  # type: asyncio.Queue[Data]
+        self.completed_queue = asyncio.Queue(maxsize=1)  # type: asyncio.Queue[Data]
 
         # put() sets this event to tell get() that a message can be fetched.
         self.message_complete = asyncio.Event()

--- a/sanic/worker/state.py
+++ b/sanic/worker/state.py
@@ -1,7 +1,6 @@
 from collections.abc import Mapping
-from typing import Any, Dict, ItemsView, Iterator, KeysView, List
+from typing import Any, Dict, ItemsView, Iterator, KeysView, List, ValuesView
 from typing import Mapping as MappingType
-from typing import ValuesView
 
 
 dict

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[flake8]
-ignore = E203, W503

--- a/setup.py
+++ b/setup.py
@@ -59,9 +59,7 @@ def str_to_bool(val: str) -> bool:
 
 with open_local(["sanic", "__version__.py"], encoding="latin1") as fp:
     try:
-        version = re.findall(
-            r"^__version__ = \"([^']+)\"\r?$", fp.read(), re.M
-        )[0]
+        version = re.findall(r"^__version__ = \"([^']+)\"\r?$", fp.read(), re.M)[0]
     except IndexError:
         raise RuntimeError("Unable to determine version.")
 
@@ -96,9 +94,7 @@ setup_kwargs = {
     "entry_points": {"console_scripts": ["sanic = sanic.__main__:main"]},
 }
 
-env_dependency = (
-    '; sys_platform != "win32" ' 'and implementation_name == "cpython"'
-)
+env_dependency = '; sys_platform != "win32" ' 'and implementation_name == "cpython"'
 ujson = "ujson>=1.35" + env_dependency
 uvloop = "uvloop>=0.15.0" + env_dependency
 types_ujson = "types-ujson" + env_dependency
@@ -123,9 +119,7 @@ tests_require = [
     "pytest-sanic",
     "pytest-benchmark",
     "chardet==3.*",
-    "flake8",
-    "black",
-    "isort>=5.0.0",
+    "ruff",
     "bandit",
     "mypy",
     "docutils",

--- a/tox.ini
+++ b/tox.ini
@@ -20,9 +20,8 @@ commands =
 
 [testenv:lint]
 commands =
-    flake8 sanic
-    black --check --verbose sanic/
-    isort --check-only sanic
+    ruff check sanic
+    ruff format sanic --check
     slotscheck --verbose -m sanic
 
 [testenv:type-checking]


### PR DESCRIPTION
Replaces #2844 and #2843 

It is a more mild approach than #2844 in that it does not implement any large changes to the code base right now, and keeps `bandit`. I think both approaches in #2844 can be implemented over time, but I am in favor of a more gentle approach starting now, and moving towards that after the LTS.