### PR TITLE
Fix the alt svc test to run locally with explicit buffer nbytes

### DIFF
--- a/tests/test_http_alt_svc.py
+++ b/tests/test_http_alt_svc.py
@@ -42,7 +42,7 @@ def test_http1_response_has_alt_svc():
 
             """
         )
-        response = await client.recv()
+        response = await client.recv(1024)
         await client.close()
 
     @app.after_server_start


### PR DESCRIPTION
This test was not running well for me locally because there was no explicit size so it was holding the connection open longer than needed.