### PR TITLE
Better exception on multiprocessing context conflicts

### DIFF
--- a/guide/content/en/guide/running/manager.md
+++ b/guide/content/en/guide/running/manager.md
@@ -345,3 +345,102 @@ To run a managed custom process on Sanic, you must create a callable. If that pr
         Sanic.serve_single()
     ```
 
+## Sanic and multiprocessing
+
+Sanic makes heavy use of the [`multiprocessing` module](https://docs.python.org/3/library/multiprocessing.html) to manage the worker processes. You should generally avoid lower level usage of this module (like setting the start method) as it may interfere with the functionality of Sanic.
+
+### Start methods in Python
+
+Before explaining what Sanic tries to do, it is important to understand what the `start_method` is and why it is important. Python generally allows for three different methods of starting a process:
+
+- `fork`
+- `spawn`
+- `forkserver`
+
+The `fork` and `forkserver` methods are only available on Unix systems, and `spawn` is the only method available on Windows. On Unix systems where you have a choice, `fork` is generally the default system method.
+
+You are encouraged to read the [Python documentation](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods) to learn more about the differences between these methods. However, the important thing to know is that `fork` basically copies the entire memory of the parent process into the child process, whereas `spawn` will create a new process and then load the application into that process. This is the reason why you need to nest your Sanic `run` call inside of the `__name__ == "__main__"` block if you are not using the CLI.
+
+### Sanic and start methods
+
+By default, Sanic will try and use `spawn` as the start method. This is because it is the only method available on Windows, and it is the safest method on Unix systems. 
+
+.. column::
+
+    However, if you are running Sanic on a Unix system and you would like to use `fork` instead, you can do so by setting the `start_method` on the `Sanic` class. You will want to do this as early as possible in your application, and ideally in the global scope before you import any other modules.
+
+.. column::
+
+    ```python
+    from sanic import Sanic
+    
+    Sanic.start_method = "fork"
+    ```
+
+### Overcoming a `RuntimeError`
+
+You might have received a `RuntimeError` that looks like this:
+
+```
+RuntimeError: Start method 'spawn' was requested, but 'fork' was already set.
+```
+
+If so, that means somewhere in your application you are trying to set the start method that conflicts with what Sanic is trying to do. You have a few options to resolve this:
+
+.. column::
+
+    **OPTION 1:** You can tell Sanic that the start method has been set and to not try and set it again.
+
+.. column::
+
+    ```python
+    from sanic import Sanic
+
+    Sanic.START_METHOD_SET = True
+    ```
+
+.. column::
+
+    **OPTION 2:** You could tell Sanic that you intend to use `fork` and to not try and set it to `spawn`.
+
+.. column::
+
+    ```python
+    from sanic import Sanic
+
+    Sanic.start_method = "fork"
+    ```
+
+.. column::
+
+    **OPTION 3:** You can tell Python to use `spawn` instead of `fork` by setting the `multiprocessing` start method.
+
+.. column::
+
+    ```python
+    import multiprocessing
+
+    multiprocessing.set_start_method("spawn")
+    ```
+
+In any of these options, you should run this code as early as possible in your application. Depending upon exactly what your specific scenario is, you may need to combine some of the options.
+
+.. note::
+
+    The potential issues that arise from this problem are usually easily solved by just allowing Sanic to be in charge of multiprocessing. This usually means making use of the `main_process_start` and `main_process_ready` listeners to deal with multiprocessing issues. For example, you should move instantiating multiprocessing primitives that do a lot of work under the hood from the global scope and into a listener.
+    
+    ```python
+    # This is BAD; avoid the global scope
+    from multiprocessing import Queue
+    
+    q = Queue()
+    ```
+    
+    ```python
+    # This is GOOD; the queue is made in a listener and shared to all the processes on the shared_ctx
+    from multiprocessing import Queue
+
+    @app.main_process_start
+    async def main_process_start(app):
+        app.shared_ctx.q = Queue()
+    ```

--- a/guide/webapp/endpoint/search.py
+++ b/guide/webapp/endpoint/search.py
@@ -18,7 +18,7 @@ async def _search(request: Request, language: str, searcher: Searcher):
     return html(str(builder))
 
 
-@bp.after_server_start
+@bp.before_server_start
 async def setup_search(app: Sanic):
     stemmer = Stemmer()
     pages: list[Page] = app.ctx.pages

--- a/guide/webapp/worker/factory.py
+++ b/guide/webapp/worker/factory.py
@@ -37,13 +37,9 @@ def create_app(root: Path) -> Sanic:
     app.config.STYLE_DIR = root / "style"
     app.config.NODE_MODULES_DIR = root / "node_modules"
     app.config.LANGUAGES = ["en"]
-    app.config.SIDEBAR = load_menu(
-        app.config.CONFIG_DIR / "en" / "sidebar.yaml"
-    )
+    app.config.SIDEBAR = load_menu(app.config.CONFIG_DIR / "en" / "sidebar.yaml")
     app.config.NAVBAR = load_menu(app.config.CONFIG_DIR / "en" / "navbar.yaml")
-    app.config.GENERAL = load_config(
-        app.config.CONFIG_DIR / "en" / "general.yaml"
-    )
+    app.config.GENERAL = load_config(app.config.CONFIG_DIR / "en" / "general.yaml")
 
     setup_livereload(app)
     setup_style(app)
@@ -51,7 +47,7 @@ def create_app(root: Path) -> Sanic:
 
     app.static("/assets/", app.config.PUBLIC_DIR / "assets")
 
-    @app.before_server_start
+    @app.before_server_start(priority=1)
     async def setup(app: Sanic):
         app.ext.dependency(PageRenderer(base_title="Sanic User Guide"))
         page_order = _compile_sidebar_order(app.config.SIDEBAR)
@@ -73,9 +69,7 @@ def create_app(root: Path) -> Sanic:
     ):
         # TODO: Add more language support
         if language != "api" and language not in app.config.LANGUAGES:
-            return redirect(
-                request.app.url_for("page", language="en", path=path)
-            )
+            return redirect(request.app.url_for("page", language="en", path=path))
         if path in KNOWN_REDIRECTS:
             return redirect(
                 request.app.url_for(
@@ -95,8 +89,6 @@ def create_app(root: Path) -> Sanic:
 
     @app.on_request
     async def set_language(request: Request):
-        request.ctx.language = request.match_info.get(
-            "language", Page.DEFAULT_LANGUAGE
-        )
+        request.ctx.language = request.match_info.get("language", Page.DEFAULT_LANGUAGE)
 
     return app

--- a/sanic/mixins/startup.py
+++ b/sanic/mixins/startup.py
@@ -936,6 +936,8 @@ class StartupMixin(metaclass=SanicMeta):
                     "was already set.\nFor more information, see: "
                     "https://sanic.dev/en/guide/running/manager.html#overcoming-a-coderuntimeerrorcode"
                 ) from None
+            else:
+                raise
         cls.START_METHOD_SET = True
 
     @classmethod

--- a/sanic/mixins/startup.py
+++ b/sanic/mixins/startup.py
@@ -114,8 +114,7 @@ class StartupMixin(metaclass=SanicMeta):
         """
         if not self.asgi:
             if self.config.USE_UVLOOP is True or (
-                isinstance(self.config.USE_UVLOOP, Default)
-                and not OS_IS_WINDOWS
+                isinstance(self.config.USE_UVLOOP, Default) and not OS_IS_WINDOWS
             ):
                 try_use_uvloop()
             elif OS_IS_WINDOWS:
@@ -387,8 +386,7 @@ class StartupMixin(metaclass=SanicMeta):
 
         if single_process and (fast or (workers > 1) or auto_reload):
             raise RuntimeError(
-                "Single process cannot be run with multiple workers "
-                "or auto-reload"
+                "Single process cannot be run with multiple workers " "or auto-reload"
             )
 
         if register_sys_signals is False and not single_process:
@@ -407,9 +405,7 @@ class StartupMixin(metaclass=SanicMeta):
             for directory in reload_dir:
                 direc = Path(directory)
                 if not direc.is_dir():
-                    logger.warning(
-                        f"Directory {directory} could not be located"
-                    )
+                    logger.warning(f"Directory {directory} could not be located")
                 self.state.reload_dirs.add(Path(directory))
 
         if loop is not None:
@@ -424,9 +420,7 @@ class StartupMixin(metaclass=SanicMeta):
             host, port = self.get_address(host, port, version, auto_tls)
 
         if protocol is None:
-            protocol = (
-                WebSocketProtocol if self.websocket_enabled else HttpProtocol
-            )
+            protocol = WebSocketProtocol if self.websocket_enabled else HttpProtocol
 
         # Set explicitly passed configuration values
         for attribute, value in {
@@ -462,9 +456,7 @@ class StartupMixin(metaclass=SanicMeta):
             register_sys_signals=register_sys_signals,
             auto_tls=auto_tls,
         )
-        self.state.server_info.append(
-            ApplicationServerInfo(settings=server_settings)
-        )
+        self.state.server_info.append(ApplicationServerInfo(settings=server_settings))
 
         # if self.config.USE_UVLOOP is True or (
         #     self.config.USE_UVLOOP is _default and not OS_IS_WINDOWS
@@ -560,9 +552,7 @@ class StartupMixin(metaclass=SanicMeta):
             host, port = host, port = self.get_address(host, port)
 
         if protocol is None:
-            protocol = (
-                WebSocketProtocol if self.websocket_enabled else HttpProtocol
-            )
+            protocol = WebSocketProtocol if self.websocket_enabled else HttpProtocol
 
         # Set explicitly passed configuration values
         for attribute, value in {
@@ -805,10 +795,7 @@ class StartupMixin(metaclass=SanicMeta):
                 reload_display += ", ".join(
                     [
                         "",
-                        *(
-                            str(path.absolute())
-                            for path in self.state.reload_dirs
-                        ),
+                        *(str(path.absolute()) for path in self.state.reload_dirs),
                     ]
                 )
             display["auto-reload"] = reload_display
@@ -818,9 +805,7 @@ class StartupMixin(metaclass=SanicMeta):
             module_name = package_name.replace("-", "_")
             try:
                 module = import_module(module_name)
-                packages.append(
-                    f"{package_name}=={module.__version__}"  # type: ignore
-                )
+                packages.append(f"{package_name}=={module.__version__}")  # type: ignore
             except ImportError:  # no cov
                 ...
 
@@ -916,9 +901,7 @@ class StartupMixin(metaclass=SanicMeta):
     @classmethod
     def _get_startup_method(cls) -> str:
         return (
-            cls.start_method
-            if not isinstance(cls.start_method, Default)
-            else "spawn"
+            cls.start_method if not isinstance(cls.start_method, Default) else "spawn"
         )
 
     @classmethod
@@ -927,7 +910,15 @@ class StartupMixin(metaclass=SanicMeta):
             return
 
         method = cls._get_startup_method()
-        set_start_method(method, force=cls.test_mode)
+        try:
+            set_start_method(method, force=cls.test_mode)
+        except RuntimeError:
+            ctx = get_context()
+            if ctx.get_start_method() != method:
+                raise RuntimeError(
+                    f"Start method '{method}' was requested, but '{ctx.get_start_method()}' "
+                    "was already set."
+                ) from None
         cls.START_METHOD_SET = True
 
     @classmethod
@@ -999,9 +990,7 @@ class StartupMixin(metaclass=SanicMeta):
                     try:
                         primary = apps[0]
                     except IndexError:
-                        raise RuntimeError(
-                            "Did not find any applications."
-                        ) from None
+                        raise RuntimeError("Did not find any applications.") from None
 
             # This exists primarily for unit testing
             if not primary.state.server_info:  # no cov
@@ -1104,9 +1093,7 @@ class StartupMixin(metaclass=SanicMeta):
             inspector = None
             if primary.config.INSPECTOR:
                 display, extra = primary.get_motd_data()
-                packages = [
-                    pkg.strip() for pkg in display["packages"].split(",")
-                ]
+                packages = [pkg.strip() for pkg in display["packages"].split(",")]
                 module = import_module("sanic")
                 sanic_version = f"sanic=={module.__version__}"  # type: ignore
                 app_info = {
@@ -1137,9 +1124,7 @@ class StartupMixin(metaclass=SanicMeta):
             exit_code = 1
         except BaseException:
             kwargs = primary_server_info.settings
-            error_logger.exception(
-                "Experienced exception while trying to serve"
-            )
+            error_logger.exception("Experienced exception while trying to serve")
             raise
         finally:
             logger.info("Server Stopped")
@@ -1180,9 +1165,7 @@ class StartupMixin(metaclass=SanicMeta):
 
     @staticmethod
     def _get_process_states(worker_state) -> List[str]:
-        return [
-            state for s in worker_state.values() if (state := s.get("state"))
-        ]
+        return [state for s in worker_state.values() if (state := s.get("state"))]
 
     @classmethod
     def serve_single(cls, primary: Optional[Sanic] = None) -> None:
@@ -1263,9 +1246,7 @@ class StartupMixin(metaclass=SanicMeta):
         try:
             worker_serve(monitor_publisher=None, **kwargs)
         except BaseException:
-            error_logger.exception(
-                "Experienced exception while trying to serve"
-            )
+            error_logger.exception("Experienced exception while trying to serve")
             raise
         finally:
             logger.info("Server Stopped")

--- a/sanic/mixins/startup.py
+++ b/sanic/mixins/startup.py
@@ -114,7 +114,8 @@ class StartupMixin(metaclass=SanicMeta):
         """
         if not self.asgi:
             if self.config.USE_UVLOOP is True or (
-                isinstance(self.config.USE_UVLOOP, Default) and not OS_IS_WINDOWS
+                isinstance(self.config.USE_UVLOOP, Default)
+                and not OS_IS_WINDOWS
             ):
                 try_use_uvloop()
             elif OS_IS_WINDOWS:
@@ -386,7 +387,8 @@ class StartupMixin(metaclass=SanicMeta):
 
         if single_process and (fast or (workers > 1) or auto_reload):
             raise RuntimeError(
-                "Single process cannot be run with multiple workers " "or auto-reload"
+                "Single process cannot be run with multiple workers "
+                "or auto-reload"
             )
 
         if register_sys_signals is False and not single_process:
@@ -405,7 +407,9 @@ class StartupMixin(metaclass=SanicMeta):
             for directory in reload_dir:
                 direc = Path(directory)
                 if not direc.is_dir():
-                    logger.warning(f"Directory {directory} could not be located")
+                    logger.warning(
+                        f"Directory {directory} could not be located"
+                    )
                 self.state.reload_dirs.add(Path(directory))
 
         if loop is not None:
@@ -420,7 +424,9 @@ class StartupMixin(metaclass=SanicMeta):
             host, port = self.get_address(host, port, version, auto_tls)
 
         if protocol is None:
-            protocol = WebSocketProtocol if self.websocket_enabled else HttpProtocol
+            protocol = (
+                WebSocketProtocol if self.websocket_enabled else HttpProtocol
+            )
 
         # Set explicitly passed configuration values
         for attribute, value in {
@@ -456,7 +462,9 @@ class StartupMixin(metaclass=SanicMeta):
             register_sys_signals=register_sys_signals,
             auto_tls=auto_tls,
         )
-        self.state.server_info.append(ApplicationServerInfo(settings=server_settings))
+        self.state.server_info.append(
+            ApplicationServerInfo(settings=server_settings)
+        )
 
         # if self.config.USE_UVLOOP is True or (
         #     self.config.USE_UVLOOP is _default and not OS_IS_WINDOWS
@@ -552,7 +560,9 @@ class StartupMixin(metaclass=SanicMeta):
             host, port = host, port = self.get_address(host, port)
 
         if protocol is None:
-            protocol = WebSocketProtocol if self.websocket_enabled else HttpProtocol
+            protocol = (
+                WebSocketProtocol if self.websocket_enabled else HttpProtocol
+            )
 
         # Set explicitly passed configuration values
         for attribute, value in {
@@ -795,7 +805,10 @@ class StartupMixin(metaclass=SanicMeta):
                 reload_display += ", ".join(
                     [
                         "",
-                        *(str(path.absolute()) for path in self.state.reload_dirs),
+                        *(
+                            str(path.absolute())
+                            for path in self.state.reload_dirs
+                        ),
                     ]
                 )
             display["auto-reload"] = reload_display
@@ -901,7 +914,9 @@ class StartupMixin(metaclass=SanicMeta):
     @classmethod
     def _get_startup_method(cls) -> str:
         return (
-            cls.start_method if not isinstance(cls.start_method, Default) else "spawn"
+            cls.start_method
+            if not isinstance(cls.start_method, Default)
+            else "spawn"
         )
 
     @classmethod
@@ -914,10 +929,12 @@ class StartupMixin(metaclass=SanicMeta):
             set_start_method(method, force=cls.test_mode)
         except RuntimeError:
             ctx = get_context()
-            if ctx.get_start_method() != method:
+            actual = ctx.get_start_method()
+            if actual != method:
                 raise RuntimeError(
-                    f"Start method '{method}' was requested, but '{ctx.get_start_method()}' "
-                    "was already set."
+                    f"Start method '{method}' was requested, but '{actual}' "
+                    "was already set.\nFor more information, see: "
+                    "https://sanic.dev/en/guide/running/manager.html#overcoming-a-coderuntimeerrorcode"
                 ) from None
         cls.START_METHOD_SET = True
 
@@ -929,8 +946,9 @@ class StartupMixin(metaclass=SanicMeta):
         if method != actual:
             raise RuntimeError(
                 f"Start method '{method}' was requested, but '{actual}' "
-                "was actually set."
-            )
+                "was already set.\nFor more information, see: "
+                "https://sanic.dev/en/guide/running/manager.html#overcoming-a-coderuntimeerrorcode"
+            ) from None
         return get_context()
 
     @classmethod
@@ -990,7 +1008,9 @@ class StartupMixin(metaclass=SanicMeta):
                     try:
                         primary = apps[0]
                     except IndexError:
-                        raise RuntimeError("Did not find any applications.") from None
+                        raise RuntimeError(
+                            "Did not find any applications."
+                        ) from None
 
             # This exists primarily for unit testing
             if not primary.state.server_info:  # no cov
@@ -1093,7 +1113,9 @@ class StartupMixin(metaclass=SanicMeta):
             inspector = None
             if primary.config.INSPECTOR:
                 display, extra = primary.get_motd_data()
-                packages = [pkg.strip() for pkg in display["packages"].split(",")]
+                packages = [
+                    pkg.strip() for pkg in display["packages"].split(",")
+                ]
                 module = import_module("sanic")
                 sanic_version = f"sanic=={module.__version__}"  # type: ignore
                 app_info = {
@@ -1124,7 +1146,9 @@ class StartupMixin(metaclass=SanicMeta):
             exit_code = 1
         except BaseException:
             kwargs = primary_server_info.settings
-            error_logger.exception("Experienced exception while trying to serve")
+            error_logger.exception(
+                "Experienced exception while trying to serve"
+            )
             raise
         finally:
             logger.info("Server Stopped")
@@ -1165,7 +1189,9 @@ class StartupMixin(metaclass=SanicMeta):
 
     @staticmethod
     def _get_process_states(worker_state) -> List[str]:
-        return [state for s in worker_state.values() if (state := s.get("state"))]
+        return [
+            state for s in worker_state.values() if (state := s.get("state"))
+        ]
 
     @classmethod
     def serve_single(cls, primary: Optional[Sanic] = None) -> None:
@@ -1246,7 +1272,9 @@ class StartupMixin(metaclass=SanicMeta):
         try:
             worker_serve(monitor_publisher=None, **kwargs)
         except BaseException:
-            error_logger.exception("Experienced exception while trying to serve")
+            error_logger.exception(
+                "Experienced exception while trying to serve"
+            )
             raise
         finally:
             logger.info("Server Stopped")

--- a/tests/worker/test_startup.py
+++ b/tests/worker/test_startup.py
@@ -1,8 +1,10 @@
 from unittest.mock import patch
 
-import pytest
+import pytest, sys
 
 from sanic import Sanic
+
+from multiprocessing import Queue, set_start_method
 
 
 @pytest.mark.parametrize(
@@ -23,3 +25,12 @@ def test_get_context(start_method, platform, expected):
         Sanic.start_method = start_method
     with patch("sys.platform", platform):
         assert Sanic._get_startup_method() == expected
+
+
+@pytest.mark.skipif(not sys.platform.startswith("linux"), reason="Only test on Linux")
+def test_set_startup_catch():
+    Sanic.START_METHOD_SET = False
+    set_start_method("fork", force=True)
+    Sanic.test_mode = False
+    Sanic._set_startup_method()
+    Sanic.test_mode = True

--- a/tests/worker/test_startup.py
+++ b/tests/worker/test_startup.py
@@ -32,5 +32,10 @@ def test_set_startup_catch():
     Sanic.START_METHOD_SET = False
     set_start_method("fork", force=True)
     Sanic.test_mode = False
-    Sanic._set_startup_method()
+    message = (
+        "Start method 'spawn' was requested, but 'fork' was already set.\n"
+        "For more information, see: https://sanic.dev/en/guide/running/manager.html#overcoming-a-coderuntimeerrorcode"
+    )
+    with pytest.raises(RuntimeError, match=message):
+        Sanic._set_startup_method()
     Sanic.test_mode = True


### PR DESCRIPTION
Since Sanic tries to set the multiprocessing context, there is a more clear error when something goes wrong. This will point the user to the docs for how to deal with the issue.