### PR TITLE
Add Hub Mode for inspector

### DIFF
--- a/sanic/config.py
+++ b/sanic/config.py
@@ -50,6 +50,9 @@ DEFAULT_CONFIG = {
     "INSPECTOR_TLS_KEY": _default,
     "INSPECTOR_TLS_CERT": _default,
     "INSPECTOR_API_KEY": "",
+    "INSPECTOR_HUB_MODE": _default,
+    "INSPECTOR_HUB_HOST": "",
+    "INSPECTOR_HUB_PORT": 0,
     "KEEP_ALIVE_TIMEOUT": 120,
     "KEEP_ALIVE": True,
     "LOCAL_CERT_CREATOR": LocalCertCreator.AUTO,
@@ -108,6 +111,9 @@ class Config(dict, metaclass=DescriptorMeta):
     INSPECTOR_TLS_KEY: Union[Path, str, Default]
     INSPECTOR_TLS_CERT: Union[Path, str, Default]
     INSPECTOR_API_KEY: str
+    INSPECTOR_HUB_MODE: Union[bool, Default]
+    INSPECTOR_HUB_HOST: str
+    INSPECTOR_HUB_PORT: int
     KEEP_ALIVE_TIMEOUT: int
     KEEP_ALIVE: bool
     LOCAL_CERT_CREATOR: Union[str, LocalCertCreator]
@@ -135,9 +141,7 @@ class Config(dict, metaclass=DescriptorMeta):
 
     def __init__(
         self,
-        defaults: Optional[
-            Dict[str, Union[str, bool, int, float, None]]
-        ] = None,
+        defaults: Optional[Dict[str, Union[str, bool, int, float, None]]] = None,
         env_prefix: Optional[str] = SANIC_PREFIX,
         keep_alive: Optional[bool] = None,
         *,
@@ -237,9 +241,7 @@ class Config(dict, metaclass=DescriptorMeta):
         if attr == "LOCAL_CERT_CREATOR" and not isinstance(
             self.LOCAL_CERT_CREATOR, LocalCertCreator
         ):
-            self.LOCAL_CERT_CREATOR = LocalCertCreator[
-                self.LOCAL_CERT_CREATOR.upper()
-            ]
+            self.LOCAL_CERT_CREATOR = LocalCertCreator[self.LOCAL_CERT_CREATOR.upper()]
         elif attr == "DEPRECATION_FILTER":
             self._configure_warnings()
 

--- a/sanic/mixins/startup.py
+++ b/sanic/mixins/startup.py
@@ -114,8 +114,7 @@ class StartupMixin(metaclass=SanicMeta):
         """
         if not self.asgi:
             if self.config.USE_UVLOOP is True or (
-                isinstance(self.config.USE_UVLOOP, Default)
-                and not OS_IS_WINDOWS
+                isinstance(self.config.USE_UVLOOP, Default) and not OS_IS_WINDOWS
             ):
                 try_use_uvloop()
             elif OS_IS_WINDOWS:
@@ -387,8 +386,7 @@ class StartupMixin(metaclass=SanicMeta):
 
         if single_process and (fast or (workers > 1) or auto_reload):
             raise RuntimeError(
-                "Single process cannot be run with multiple workers "
-                "or auto-reload"
+                "Single process cannot be run with multiple workers " "or auto-reload"
             )
 
         if register_sys_signals is False and not single_process:
@@ -407,9 +405,7 @@ class StartupMixin(metaclass=SanicMeta):
             for directory in reload_dir:
                 direc = Path(directory)
                 if not direc.is_dir():
-                    logger.warning(
-                        f"Directory {directory} could not be located"
-                    )
+                    logger.warning(f"Directory {directory} could not be located")
                 self.state.reload_dirs.add(Path(directory))
 
         if loop is not None:
@@ -424,9 +420,7 @@ class StartupMixin(metaclass=SanicMeta):
             host, port = self.get_address(host, port, version, auto_tls)
 
         if protocol is None:
-            protocol = (
-                WebSocketProtocol if self.websocket_enabled else HttpProtocol
-            )
+            protocol = WebSocketProtocol if self.websocket_enabled else HttpProtocol
 
         # Set explicitly passed configuration values
         for attribute, value in {
@@ -462,9 +456,7 @@ class StartupMixin(metaclass=SanicMeta):
             register_sys_signals=register_sys_signals,
             auto_tls=auto_tls,
         )
-        self.state.server_info.append(
-            ApplicationServerInfo(settings=server_settings)
-        )
+        self.state.server_info.append(ApplicationServerInfo(settings=server_settings))
 
         # if self.config.USE_UVLOOP is True or (
         #     self.config.USE_UVLOOP is _default and not OS_IS_WINDOWS
@@ -560,9 +552,7 @@ class StartupMixin(metaclass=SanicMeta):
             host, port = host, port = self.get_address(host, port)
 
         if protocol is None:
-            protocol = (
-                WebSocketProtocol if self.websocket_enabled else HttpProtocol
-            )
+            protocol = WebSocketProtocol if self.websocket_enabled else HttpProtocol
 
         # Set explicitly passed configuration values
         for attribute, value in {
@@ -805,10 +795,7 @@ class StartupMixin(metaclass=SanicMeta):
                 reload_display += ", ".join(
                     [
                         "",
-                        *(
-                            str(path.absolute())
-                            for path in self.state.reload_dirs
-                        ),
+                        *(str(path.absolute()) for path in self.state.reload_dirs),
                     ]
                 )
             display["auto-reload"] = reload_display
@@ -914,9 +901,7 @@ class StartupMixin(metaclass=SanicMeta):
     @classmethod
     def _get_startup_method(cls) -> str:
         return (
-            cls.start_method
-            if not isinstance(cls.start_method, Default)
-            else "spawn"
+            cls.start_method if not isinstance(cls.start_method, Default) else "spawn"
         )
 
     @classmethod
@@ -1010,9 +995,7 @@ class StartupMixin(metaclass=SanicMeta):
                     try:
                         primary = apps[0]
                     except IndexError:
-                        raise RuntimeError(
-                            "Did not find any applications."
-                        ) from None
+                        raise RuntimeError("Did not find any applications.") from None
 
             # This exists primarily for unit testing
             if not primary.state.server_info:  # no cov
@@ -1115,9 +1098,7 @@ class StartupMixin(metaclass=SanicMeta):
             inspector = None
             if primary.config.INSPECTOR:
                 display, extra = primary.get_motd_data()
-                packages = [
-                    pkg.strip() for pkg in display["packages"].split(",")
-                ]
+                packages = [pkg.strip() for pkg in display["packages"].split(",")]
                 module = import_module("sanic")
                 sanic_version = f"sanic=={module.__version__}"  # type: ignore
                 app_info = {
@@ -1134,8 +1115,12 @@ class StartupMixin(metaclass=SanicMeta):
                     primary.config.INSPECTOR_API_KEY,
                     primary.config.INSPECTOR_TLS_KEY,
                     primary.config.INSPECTOR_TLS_CERT,
+                    primary.config.INSPECTOR_HUB_MODE,
+                    primary.config.INSPECTOR_HUB_HOST,
+                    primary.config.INSPECTOR_HUB_PORT,
                 )
-                manager.manage("Inspector", inspector, {}, transient=False)
+                # TODO: Change back to false
+                manager.manage("Inspector", inspector, {}, transient=True)
 
             primary._inspector = inspector
             primary._manager = manager
@@ -1148,9 +1133,7 @@ class StartupMixin(metaclass=SanicMeta):
             exit_code = 1
         except BaseException:
             kwargs = primary_server_info.settings
-            error_logger.exception(
-                "Experienced exception while trying to serve"
-            )
+            error_logger.exception("Experienced exception while trying to serve")
             raise
         finally:
             logger.info("Server Stopped")
@@ -1191,9 +1174,7 @@ class StartupMixin(metaclass=SanicMeta):
 
     @staticmethod
     def _get_process_states(worker_state) -> List[str]:
-        return [
-            state for s in worker_state.values() if (state := s.get("state"))
-        ]
+        return [state for s in worker_state.values() if (state := s.get("state"))]
 
     @classmethod
     def serve_single(cls, primary: Optional[Sanic] = None) -> None:
@@ -1274,9 +1255,7 @@ class StartupMixin(metaclass=SanicMeta):
         try:
             worker_serve(monitor_publisher=None, **kwargs)
         except BaseException:
-            error_logger.exception(
-                "Experienced exception while trying to serve"
-            )
+            error_logger.exception("Experienced exception while trying to serve")
             raise
         finally:
             logger.info("Server Stopped")

--- a/sanic/worker/inspector.py
+++ b/sanic/worker/inspector.py
@@ -2,16 +2,59 @@ from __future__ import annotations
 
 from datetime import datetime
 from inspect import isawaitable
+from logging import debug
 from multiprocessing.connection import Connection
 from os import environ
 from pathlib import Path
-from typing import Any, Dict, Mapping, Union
-
+from typing import TYPE_CHECKING, Any, Dict, Mapping, Union, Tuple
+from asyncio import sleep
 from sanic.exceptions import Unauthorized
-from sanic.helpers import Default
+from sanic.helpers import Default, _default
 from sanic.log import logger
 from sanic.request import Request
 from sanic.response import json
+from dataclasses import dataclass
+from websockets import connection, connect, ConnectionClosed
+from sanic.server.websockets.impl import WebsocketImplProtocol
+
+if TYPE_CHECKING:
+    from sanic import Sanic
+
+
+@dataclass
+class NodeState:
+    ...
+
+
+@dataclass
+class HubState:
+    nodes: Dict[str, NodeState]
+
+
+class NodeClient:
+    def __init__(self, hub_host: str, hub_port: int) -> None:
+        self.hub_host = hub_host
+        self.hub_port = hub_port
+
+    async def run(self, state_getter) -> None:
+        try:
+            async for ws in connect(f"ws://{self.hub_host}:{self.hub_port}/hub"):
+                try:
+                    await self._run_node(ws, state_getter)
+                except ConnectionClosed:
+                    continue
+        except BaseException:
+            ...
+        finally:
+            print("Node out")
+
+    def _setup_ws_client(self, hub_host: str, hub_port: int) -> connection:
+        return connect(f"ws://{hub_host}:{hub_port}/hub")
+
+    async def _run_node(self, ws: connection, state_getter) -> None:
+        while True:
+            await ws.send(str(state_getter()))
+            await sleep(3)
 
 
 class Inspector:
@@ -46,7 +89,13 @@ class Inspector:
         api_key: str,
         tls_key: Union[Path, str, Default],
         tls_cert: Union[Path, str, Default],
+        hub_mode: Union[bool, Default] = _default,
+        hub_host: str = "",
+        hub_port: int = 0,
     ):
+        hub_mode, node_mode = self._detect_modes(
+            hub_mode, host, port, hub_host, hub_port
+        )
         self._publisher = publisher
         self.app_info = app_info
         self.worker_state = worker_state
@@ -55,6 +104,10 @@ class Inspector:
         self.api_key = api_key
         self.tls_key = tls_key
         self.tls_cert = tls_cert
+        self.hub_mode = hub_mode
+        self.node_mode = node_mode
+        self.hub_host = hub_host
+        self.hub_port = hub_port
 
     def __call__(self, run=True, **_) -> Inspector:
         from sanic import Sanic
@@ -70,14 +123,44 @@ class Inspector:
                 if not isinstance(self.tls_key, Default)
                 and not isinstance(self.tls_cert, Default)
                 else None,
+                debug=True,
             )
         return self
+
+    def _detect_modes(
+        self,
+        hub_mode: Union[bool, Default],
+        host: str,
+        port: int,
+        hub_host: str,
+        hub_port: int,
+    ) -> Tuple[bool, bool]:
+        print(hub_mode, host, port, hub_host, hub_port)
+        if hub_host == host and hub_port == port:
+            if not hub_mode:
+                raise ValueError(
+                    "Hub mode must be enabled when using the same host and port"
+                )
+            hub_mode = True
+        if (hub_host and not hub_port) or (hub_port and not hub_host):
+            raise ValueError("Both hub host and hub port must be specified")
+        if hub_mode is True:
+            return True, False
+        elif hub_host and hub_port:
+            return False, True
+        else:
+            return False, False
 
     def _setup(self):
         self.app.get("/")(self._info)
         self.app.post("/<action:str>")(self._action)
         if self.api_key:
             self.app.on_request(self._authentication)
+        if self.hub_mode:
+            self.app.before_server_start(self._setup_hub)
+            self.app.websocket("/hub")(self._hub)
+        if self.node_mode:
+            self.app.before_server_start(self._run_node)
         environ["SANIC_IGNORE_PRODUCTION_WARNING"] = "true"
 
     def _authentication(self, request: Request) -> None:
@@ -154,3 +237,24 @@ class Inspector:
         """Shutdown the workers"""
         message = "__TERMINATE__"
         self._publisher.send(message)
+
+    def _setup_hub(self, app: Sanic) -> None:
+        app.ctx.hub_state = HubState(nodes={})
+
+    @staticmethod
+    async def _hub(
+        request: Request,
+        websocket: WebsocketImplProtocol,
+    ) -> None:
+        hub_state = request.app.ctx.hub_state
+        hub_state.nodes[request.id] = NodeState()
+        while True:
+            message = await websocket.recv()
+            if message == "ping":
+                await websocket.send("pong")
+            else:
+                logger.info("Hub received message: %s", message)
+
+    async def _run_node(self, app: Sanic) -> None:
+        client = NodeClient(self.hub_host, self.hub_port)
+        app.add_task(client.run(self._state_to_json))


### PR DESCRIPTION
Each individual run of Sanic sort of runs on its own. The Inspector is a very powerful tool that can be used for introspection, monitoring, and scalability. However, it really is only useful on that individual run.

This PR brings the concept of a centralized hub that collects information from multiple independent instances to aggregate in a single Inspector (called the Hub).

More details as the idea if further fleshed out.