### PR TITLE
Fixed a little typo in log.py

### DIFF
--- a/sanic/log.py
+++ b/sanic/log.py
@@ -75,7 +75,7 @@ LOGGING_CONFIG_DEFAULTS: Dict[str, Any] = dict(  # no cov
     },
 )
 """
-Defult logging configuration
+Default logging configuration
 """
 
 


### PR DESCRIPTION
I stumbled across a small typo in a docstring.