### PR TITLE
Added support to Multiplexer and Manager to terminate durable workers

### DIFF
--- a/sanic/worker/manager.py
+++ b/sanic/worker/manager.py
@@ -417,7 +417,7 @@ class WorkerManager:
         worker = self.durable.get(ident)
         if not worker:
             error_logger.error(
-                f"Durable worker termination failed because {ident} not found."
+                "Durable worker termination failed (%s not found).", worker
             )
             return
         for process in worker.processes:

--- a/sanic/worker/multiplexer.py
+++ b/sanic/worker/multiplexer.py
@@ -150,7 +150,7 @@ class WorkerMultiplexer:
         """Terminate a worker.
 
         Args:
-            name (str): The name of the worker to terminate.
+            ident (str): The name of the worker to terminate.
         """
         self._monitor_publisher.send(f"__TERMINATE_WORKER__:{ident}")
 

--- a/sanic/worker/multiplexer.py
+++ b/sanic/worker/multiplexer.py
@@ -146,6 +146,14 @@ class WorkerMultiplexer:
         message = "__TERMINATE_EARLY__" if early else "__TERMINATE__"
         self._monitor_publisher.send(message)
 
+    def terminate_worker(self, ident: str):
+        """Terminate a worker.
+
+        Args:
+            name (str): The name of the worker to terminate.
+        """
+        self._monitor_publisher.send(f"__TERMINATE_WORKER__:{ident}")
+
     @property
     def pid(self) -> int:
         """The process ID of the worker."""

--- a/tests/worker/test_multiplexer.py
+++ b/tests/worker/test_multiplexer.py
@@ -102,6 +102,13 @@ def test_terminate(monitor_publisher: Mock, m: WorkerMultiplexer):
     monitor_publisher.send.assert_called_once_with("__TERMINATE__")
 
 
+def test_terminate_worker(monitor_publisher: Mock, m: WorkerMultiplexer):
+    m.terminate_worker("foo,bar")
+    monitor_publisher.send.assert_called_once_with(
+        "__TERMINATE_WORKER__:foo,bar"
+    )
+
+
 def test_scale(monitor_publisher: Mock, m: WorkerMultiplexer):
     m.scale(99)
     monitor_publisher.send.assert_called_once_with("__SCALE__:99")


### PR DESCRIPTION
I had a usecase for this in a project I'm working on and I thought it might be useful.  Happy to make any changes to be more in-line with the existing codebase or planned trajectory.