### PR TITLE
Auto generate route name

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -223,7 +223,7 @@ class Sanic(
         "strict_slashes",
         "websocket_enabled",
         "websocket_tasks",
-        "generate_name",
+        "unique_route_name_generate",
     )
 
     _app_registry: ClassVar[Dict[str, "Sanic"]] = {}
@@ -248,7 +248,7 @@ class Sanic(
         inspector: bool = False,
         inspector_class: Optional[Type[Inspector]] = None,
         certloader_class: Optional[Type[CertLoader]] = None,
-        generate_name: bool = False,
+        unique_route_name_generate: bool = False,
     ) -> None:
         ...
 
@@ -271,7 +271,7 @@ class Sanic(
         inspector: bool = False,
         inspector_class: Optional[Type[Inspector]] = None,
         certloader_class: Optional[Type[CertLoader]] = None,
-        generate_name: bool = False,
+        unique_route_name_generate: bool = False,
     ) -> None:
         ...
 
@@ -294,7 +294,7 @@ class Sanic(
         inspector: bool = False,
         inspector_class: Optional[Type[Inspector]] = None,
         certloader_class: Optional[Type[CertLoader]] = None,
-        generate_name: bool = False,
+        unique_route_name_generate: bool = False,
     ) -> None:
         ...
 
@@ -317,7 +317,7 @@ class Sanic(
         inspector: bool = False,
         inspector_class: Optional[Type[Inspector]] = None,
         certloader_class: Optional[Type[CertLoader]] = None,
-        generate_name: bool = False,
+        unique_route_name_generate: bool = False,
     ) -> None:
         ...
 
@@ -339,7 +339,7 @@ class Sanic(
         inspector: bool = False,
         inspector_class: Optional[Type[Inspector]] = None,
         certloader_class: Optional[Type[CertLoader]] = None,
-        generate_name: bool = False,
+        unique_route_name_generate: bool = False,
     ) -> None:
         super().__init__(name=name)
         # logging
@@ -396,7 +396,7 @@ class Sanic(
         self.strict_slashes: bool = strict_slashes
         self.websocket_enabled: bool = False
         self.websocket_tasks: Set[Future[Any]] = set()
-        self.generate_name = generate_name
+        self.unique_route_name_generate = unique_route_name_generate
 
         # Register alternative method names
         self.go_fast = self.run

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -223,6 +223,7 @@ class Sanic(
         "strict_slashes",
         "websocket_enabled",
         "websocket_tasks",
+        "generate_name",
     )
 
     _app_registry: ClassVar[Dict[str, "Sanic"]] = {}
@@ -247,6 +248,7 @@ class Sanic(
         inspector: bool = False,
         inspector_class: Optional[Type[Inspector]] = None,
         certloader_class: Optional[Type[CertLoader]] = None,
+        generate_name: bool = False,
     ) -> None:
         ...
 
@@ -269,6 +271,7 @@ class Sanic(
         inspector: bool = False,
         inspector_class: Optional[Type[Inspector]] = None,
         certloader_class: Optional[Type[CertLoader]] = None,
+        generate_name: bool = False,
     ) -> None:
         ...
 
@@ -291,6 +294,7 @@ class Sanic(
         inspector: bool = False,
         inspector_class: Optional[Type[Inspector]] = None,
         certloader_class: Optional[Type[CertLoader]] = None,
+        generate_name: bool = False,
     ) -> None:
         ...
 
@@ -313,6 +317,7 @@ class Sanic(
         inspector: bool = False,
         inspector_class: Optional[Type[Inspector]] = None,
         certloader_class: Optional[Type[CertLoader]] = None,
+        generate_name: bool = False,
     ) -> None:
         ...
 
@@ -334,6 +339,7 @@ class Sanic(
         inspector: bool = False,
         inspector_class: Optional[Type[Inspector]] = None,
         certloader_class: Optional[Type[CertLoader]] = None,
+        generate_name: bool = False,
     ) -> None:
         super().__init__(name=name)
         # logging
@@ -390,6 +396,7 @@ class Sanic(
         self.strict_slashes: bool = strict_slashes
         self.websocket_enabled: bool = False
         self.websocket_tasks: Set[Future[Any]] = set()
+        self.generate_name = generate_name
 
         # Register alternative method names
         self.go_fast = self.run

--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -117,6 +117,7 @@ class Blueprint(BaseSanic):
         "version",
         "version_prefix",
         "websocket_routes",
+        "generate_name",
     )
 
     def __init__(
@@ -127,6 +128,7 @@ class Blueprint(BaseSanic):
         version: Optional[Union[int, str, float]] = None,
         strict_slashes: Optional[bool] = None,
         version_prefix: str = "/v",
+        generate_name: bool = False,
     ):
         super().__init__(name=name)
         self.reset()
@@ -142,6 +144,7 @@ class Blueprint(BaseSanic):
         )
         self.version = version
         self.version_prefix = version_prefix
+        self.generate_name = generate_name
 
     def __repr__(self) -> str:
         args = ", ".join(

--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -117,7 +117,7 @@ class Blueprint(BaseSanic):
         "version",
         "version_prefix",
         "websocket_routes",
-        "generate_name",
+        "unique_route_name_generate",
     )
 
     def __init__(
@@ -128,7 +128,7 @@ class Blueprint(BaseSanic):
         version: Optional[Union[int, str, float]] = None,
         strict_slashes: Optional[bool] = None,
         version_prefix: str = "/v",
-        generate_name: bool = False,
+        unique_route_name_generate: bool = False,
     ):
         super().__init__(name=name)
         self.reset()
@@ -144,7 +144,7 @@ class Blueprint(BaseSanic):
         )
         self.version = version
         self.version_prefix = version_prefix
-        self.generate_name = generate_name
+        self.unique_route_name_generate = unique_route_name_generate
 
     def __repr__(self) -> str:
         args = ", ".join(

--- a/sanic/mixins/base.py
+++ b/sanic/mixins/base.py
@@ -9,13 +9,15 @@ class BaseMixin(metaclass=SanicMeta):
     name: str
     strict_slashes: Optional[bool]
 
-    def _generate_name(self, *objects) -> str:
+    def _generate_name(self, *objects, methods=None, uri=None) -> str:
         name = None
+        named_route = False
 
         for obj in objects:
             if obj:
                 if isinstance(obj, str):
                     name = obj
+                    named_route = True
                     break
 
                 try:
@@ -32,6 +34,13 @@ class BaseMixin(metaclass=SanicMeta):
             raise ValueError("Could not generate a name for handler")
 
         if not name.startswith(f"{self.name}."):
+            if not named_route:
+                if methods:
+                    methods = "_".join(methods)
+                    name = f"{name}_{methods}"
+                if uri:
+                    # uri = uri.replace("/", "/")
+                    name = f"{name}_{uri}"
             name = f"{self.name}.{name}"
 
         return name

--- a/sanic/mixins/base.py
+++ b/sanic/mixins/base.py
@@ -9,15 +9,15 @@ class BaseMixin(metaclass=SanicMeta):
     name: str
     strict_slashes: Optional[bool]
 
-    def _generate_name(self, *objects, route_generate=False, methods=None, uri=None) -> str:
+    def _generate_name(self, *objects, unique_route_name_generate=False, methods=None, uri=None) -> str:
         name = None
-        named_route = False
+        _named_route = False
 
         for obj in objects:
             if obj:
                 if isinstance(obj, str):
                     name = obj
-                    named_route = True
+                    _named_route = True
                     break
 
                 try:
@@ -34,12 +34,12 @@ class BaseMixin(metaclass=SanicMeta):
             raise ValueError("Could not generate a name for handler")
 
         if not name.startswith(f"{self.name}."):
-            if route_generate and not named_route:
+            if unique_route_name_generate and not _named_route:
                 if methods:
-                    methods = "_".join(methods)
+                    methods = "-".join(methods)
                     name = f"{name}_{methods}"
                 if uri:
-                    # uri = uri.replace("/", "/")
+                    uri = uri.replace("/", "S")
                     name = f"{name}_{uri}"
             name = f"{self.name}.{name}"
 

--- a/sanic/mixins/base.py
+++ b/sanic/mixins/base.py
@@ -9,7 +9,7 @@ class BaseMixin(metaclass=SanicMeta):
     name: str
     strict_slashes: Optional[bool]
 
-    def _generate_name(self, *objects, methods=None, uri=None) -> str:
+    def _generate_name(self, *objects, route_generate=False, methods=None, uri=None) -> str:
         name = None
         named_route = False
 
@@ -34,7 +34,7 @@ class BaseMixin(metaclass=SanicMeta):
             raise ValueError("Could not generate a name for handler")
 
         if not name.startswith(f"{self.name}."):
-            if not named_route:
+            if route_generate and not named_route:
                 if methods:
                     methods = "_".join(methods)
                     name = f"{name}_{methods}"

--- a/sanic/mixins/routes.py
+++ b/sanic/mixins/routes.py
@@ -139,7 +139,7 @@ class RouteMixin(BaseMixin, metaclass=SanicMeta):
                 # variable will be a tuple of (existing routes, handler fn)
                 _, handler = handler
 
-            name = self._generate_name(name, handler)
+            name = self._generate_name(name, handler, methods=methods, uri=uri)
 
             if isinstance(host, str):
                 host = frozenset([host])

--- a/sanic/mixins/routes.py
+++ b/sanic/mixins/routes.py
@@ -139,7 +139,9 @@ class RouteMixin(BaseMixin, metaclass=SanicMeta):
                 # variable will be a tuple of (existing routes, handler fn)
                 _, handler = handler
 
-            name = self._generate_name(name, handler, route_generate=self.generate_name, methods=methods, uri=uri)
+            name = self._generate_name(
+                name, handler, unique_route_name_generate=self.unique_route_name_generate, methods=methods, uri=uri
+            )
 
             if isinstance(host, str):
                 host = frozenset([host])

--- a/sanic/mixins/routes.py
+++ b/sanic/mixins/routes.py
@@ -139,7 +139,7 @@ class RouteMixin(BaseMixin, metaclass=SanicMeta):
                 # variable will be a tuple of (existing routes, handler fn)
                 _, handler = handler
 
-            name = self._generate_name(name, handler, methods=methods, uri=uri)
+            name = self._generate_name(name, handler, route_generate=self.generate_name, methods=methods, uri=uri)
 
             if isinstance(host, str):
                 host = frozenset([host])

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -308,6 +308,34 @@ def test_bp_with_host_list(app: Sanic):
     assert "test_bp_with_host_list.test_bp_host.handler2" in route_names
 
 
+def test_bp_with_auto_name_generate(app: Sanic):
+    bp = Blueprint(
+        "test_bp_host",
+        url_prefix="/test1",
+        host=["example.com", "sub.example.com"],
+        generate_name=True,
+    )
+
+    @bp.route("/")
+    def handler1(request):
+        return text("Hello")
+
+    @bp.route("/", host=["sub1.example.com"])
+    def handler2(request):
+        return text("Hello subdomain!")
+
+    @bp.route("/route_with_name", methods=["GET", "POST"], name="handler3")
+    def handler3(request):
+        return text("Hello subdomain!")
+
+    app.blueprint(bp)
+
+    route_names = [r.name for r in app.router.routes]
+    assert "test_bp_with_auto_name_generate.test_bp_host.handler1_GET_/" in route_names
+    assert "test_bp_with_auto_name_generate.test_bp_host.handler2_GET_/" in route_names
+    assert "test_bp_with_auto_name_generate.test_bp_host.handler3" in route_names
+
+
 def test_several_bp_with_host_list(app: Sanic):
     bp = Blueprint(
         "test_text",

--- a/tests/test_blueprints.py
+++ b/tests/test_blueprints.py
@@ -313,7 +313,7 @@ def test_bp_with_auto_name_generate(app: Sanic):
         "test_bp_host",
         url_prefix="/test1",
         host=["example.com", "sub.example.com"],
-        generate_name=True,
+        unique_route_name_generate=True,
     )
 
     @bp.route("/")
@@ -324,6 +324,10 @@ def test_bp_with_auto_name_generate(app: Sanic):
     def handler2(request):
         return text("Hello subdomain!")
 
+    @bp.route("/route_multiple_method", methods=["GET", "POST"])
+    def handler3(request):
+        return text("Hello subdomain!")
+
     @bp.route("/route_with_name", methods=["GET", "POST"], name="handler3")
     def handler3(request):
         return text("Hello subdomain!")
@@ -331,8 +335,9 @@ def test_bp_with_auto_name_generate(app: Sanic):
     app.blueprint(bp)
 
     route_names = [r.name for r in app.router.routes]
-    assert "test_bp_with_auto_name_generate.test_bp_host.handler1_GET_/" in route_names
-    assert "test_bp_with_auto_name_generate.test_bp_host.handler2_GET_/" in route_names
+    assert "test_bp_with_auto_name_generate.test_bp_host.handler1_GET_S" in route_names
+    assert "test_bp_with_auto_name_generate.test_bp_host.handler2_GET_S" in route_names
+    assert "test_bp_with_auto_name_generate.test_bp_host.handler3_GET-POST_Sroute_multiple_method" in route_names
     assert "test_bp_with_auto_name_generate.test_bp_host.handler3" in route_names
 
 


### PR DESCRIPTION
The ability to automatically generate names for routes has been added to Sanic. This feature is controlled by the 'generate_name' parameter available in the application, blueprint, and route definitions. Additionally, comprehensive tests have been added to ensure the correct functionality of this new feature.

a parameter added to the Sanic and Blueprint constructor
`app = Sanic(name='hello', unique_route_name_generate=True)`

in recent versions of Sanic, it's some kind of essential to assign names fo routes (it makes migrating to a new version of Sanic, very time-consuming). For example this little example: 
```python
app = Sanic(name='hello')

@app.route('/')
async def handler(request):
    await asyncio.sleep(2)
    print('Still running')
    return response.text('OK')


@app.route('/err')
async def handler(request):
    await asyncio.sleep(0.1)
    return response.text('OK')
```
by using this new argument, its becomes mandatory to assign names and be more backward compatible also naming can be ignored in most cases.