### PR TITLE
Fix typo in sanic-ext configuration readme.md file

### DIFF
--- a/guide/content/en/plugins/sanic-ext/configuration.md
+++ b/guide/content/en/plugins/sanic-ext/configuration.md
@@ -223,7 +223,7 @@ However, there are a few more configuration options that should be considered.
 
 - **Type**: `str`
 - **Default**: `"/swagger-config"`
-- **Description**: Path to serve the Swagger configurtaion
+- **Description**: Path to serve the Swagger configuration
 
 ### `oas_uri_to_json`
 


### PR DESCRIPTION
Spotted a small typo while browsing docs.
Fixing "configurtaion" to "configuration".