### PR TITLE
Healthcheck docs added extra information to enable the endpoint

### DIFF
--- a/guide/content/en/plugins/sanic-ext/health-monitor.md
+++ b/guide/content/en/plugins/sanic-ext/health-monitor.md
@@ -12,12 +12,13 @@ You can setup Sanic Extensions to monitor the health of your worker processes. T
 
 .. column::
 
-    Out of the box, the health monitor is disabled. You will need to opt-in if you would like to use it.
+    Out of the box, the health monitor is disabled. You will need to opt-in and enable the endpoint if you would like to use it.
 
 .. column::
 
     ```python
     app.config.HEALTH = True
+    app.config.HEALTH_ENDPOINT = True
     ```
 
 ## How does it work


### PR DESCRIPTION
Enabling the Health monitor extension is not enough to get it running since the endpoint also has to be enabled to be usable.
I just added a small line to specify it.

![Current documentation](https://github.com/sanic-org/sanic/assets/35530362/7e7491b7-e5e5-40d1-8e44-36522b22db44)
