### PR TITLE
Make the `.message` field on exceptions non-empty

### DIFF
--- a/sanic/exceptions.py
+++ b/sanic/exceptions.py
@@ -87,7 +87,7 @@ class SanicException(Exception):
         self.status_code = status_code or self.status_code
         self.quiet = quiet
         self.headers = headers
-        self.message = message
+        self.message = message  # type: ignore
 
 
 class HTTPException(SanicException):

--- a/sanic/exceptions.py
+++ b/sanic/exceptions.py
@@ -74,8 +74,8 @@ class SanicException(Exception):
         )
         quiet = quiet or getattr(self.__class__, "quiet", None)
         headers = headers or getattr(self.__class__, "headers", {})
-        if not isinstance(message, str):
-            # If a `bytes`-like object is provided, normalize it to a string.
+        if isinstance(message, bytes):
+            # If a `bytes` object is provided, normalize it to a string.
             message = message.decode("utf8")
         if message is None:
             cls_message = getattr(self.__class__, "message", None)

--- a/sanic/exceptions.py
+++ b/sanic/exceptions.py
@@ -76,20 +76,22 @@ class SanicException(Exception):
         headers = headers or getattr(self.__class__, "headers", {})
         if isinstance(message, bytes):
             # If a `bytes` object is provided, normalize it to a string.
-            message = message.decode("utf8")
-        if message is None:
+            message_str: str = message.decode("utf8")
+        elif message is not None:
+            message_str = message
+        else:
             cls_message = getattr(self.__class__, "message", None)
             if cls_message:
-                message = cls_message
+                message_str = cls_message
             elif status_code:
-                message = STATUS_CODES.get(status_code, b"").decode("utf8")
+                message_str = STATUS_CODES.get(status_code, b"").decode("utf8")
 
-        super().__init__(message)
+        super().__init__(message_str)
 
         self.status_code = status_code or self.status_code
         self.quiet = quiet
         self.headers = headers
-        self.message = message
+        self.message = message_str
 
 
 class HTTPException(SanicException):

--- a/sanic/exceptions.py
+++ b/sanic/exceptions.py
@@ -75,8 +75,9 @@ class SanicException(Exception):
         quiet = quiet or getattr(self.__class__, "quiet", None)
         headers = headers or getattr(self.__class__, "headers", {})
         if message is None:
-            if self.message:
-                message = self.message
+            cls_message = getattr(self.__class__, "message", None)
+            if cls_message:
+                message = cls_message
             elif status_code:
                 msg: bytes = STATUS_CODES.get(status_code, b"")
                 message = msg.decode("utf8")
@@ -86,6 +87,7 @@ class SanicException(Exception):
         self.status_code = status_code or self.status_code
         self.quiet = quiet
         self.headers = headers
+        self.message = message
 
 
 class HTTPException(SanicException):

--- a/sanic/exceptions.py
+++ b/sanic/exceptions.py
@@ -74,20 +74,22 @@ class SanicException(Exception):
         )
         quiet = quiet or getattr(self.__class__, "quiet", None)
         headers = headers or getattr(self.__class__, "headers", {})
+        if not isinstance(message, str):
+            # If a `bytes`-like object is provided, normalize it to a string.
+            message = message.decode("utf8")
         if message is None:
             cls_message = getattr(self.__class__, "message", None)
             if cls_message:
                 message = cls_message
             elif status_code:
-                msg: bytes = STATUS_CODES.get(status_code, b"")
-                message = msg.decode("utf8")
+                message = STATUS_CODES.get(status_code, b"").decode("utf8")
 
         super().__init__(message)
 
         self.status_code = status_code or self.status_code
         self.quiet = quiet
         self.headers = headers
-        self.message = message  # type: ignore
+        self.message = message
 
 
 class HTTPException(SanicException):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -402,7 +402,7 @@ def test_exception_aliases():
 
 def test_exception_message_attribute():
     assert ServerError("it failed").message == "it failed"
-    assert ServerError(b"it failed").message == b"it failed"
+    assert ServerError(b"it failed").message == "it failed"
     assert ServerError().message == str(ServerError()) == "Internal Server Error"
 
     class CustomError(SanicException):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -398,3 +398,16 @@ def test_exception_aliases():
     assert MethodNotSupported is MethodNotAllowed
     assert ContentRangeError is RangeNotSatisfiable
     assert HeaderExpectationFailed is ExpectationFailed
+
+
+def test_exception_message_attribute():
+    assert ServerError("it failed").message == "it failed"
+    assert ServerError(b"it failed").message == b"it failed"
+    assert ServerError().message == str(ServerError()) == "Internal Server Error"
+
+    class CustomError(SanicException):
+        message = "Something bad happened"
+
+    assert CustomError().message == CustomError.message == str(CustomError())
+    assert SanicException().message != ""
+    assert SanicException("").message == ""

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -403,7 +403,9 @@ def test_exception_aliases():
 def test_exception_message_attribute():
     assert ServerError("it failed").message == "it failed"
     assert ServerError(b"it failed").message == "it failed"
-    assert ServerError().message == str(ServerError()) == "Internal Server Error"
+    assert (
+        ServerError().message == str(ServerError()) == "Internal Server Error"
+    )
 
     class CustomError(SanicException):
         message = "Something bad happened"


### PR DESCRIPTION
This allows subclasses of SanicException to access their message via the `message` attribute. This makes it consistent with the `status_code`, `quiet`, `headers` attributes that were previously present on the class.

Currently, the message attribute is present on the class but not on the instance, so accessing SanicException("Failed!").message will return an empty string "" instead of the actual message "Failed!", which you can get by calling the `__str__()` method or `str()` function.

This is a bit surprising, since the .message attribute shows up in autocomplete and type-checking. It also happens for the other exceptions, like BadRequest().message == "" as well.

I set the message attribute on instances of SanicException and added tests for this new behavior.

### Doc reference

https://sanic.dev/en/guide/best-practices/exceptions.html#exception-properties