### PR TITLE
Not to remove entity headers for 412 responses

### DIFF
--- a/sanic/response/types.py
+++ b/sanic/response/types.py
@@ -104,8 +104,7 @@ class BaseHTTPResponse:
         Returns:
             Iterator[Tuple[bytes, bytes]]: A list of header tuples encoded in bytes for sending
         """  # noqa: E501
-        # TODO: Make a blacklist set of header names and then filter with that
-        if self.status in (304, 412):  # Not Modified, Precondition Failed
+        if self.status == 304:  # Not Modified
             self.headers = remove_entity_headers(self.headers)
         if has_message_body(self.status):
             self.headers.setdefault("content-type", self.content_type)


### PR DESCRIPTION
Resolves #2575

There seems to be not a reason to remove the entity headers for 412 responses, and the removal is causing the client-side timeout error.