### PR TITLE
Fix deleting a cookie that was created with secure=False

### DIFF
--- a/sanic/cookies/response.py
+++ b/sanic/cookies/response.py
@@ -392,10 +392,6 @@ class CookieJar(dict):
             This requires that secure=True, defaults to False
         :type secure_prefix: bool
         """
-
-        # Host prefix can only be used on a cookie where
-        # path=="/", domain==None, and secure==True
-
         if host_prefix and not (secure and path == "/" and domain is None):
             raise ServerError(
                 "Cannot set host_prefix on a cookie without "
@@ -406,7 +402,6 @@ class CookieJar(dict):
                 "Cannot set secure_prefix on a cookie without secure=True"
             )
 
-        # remove it from header
         cookies: List[Cookie] = self.headers.popall(self.HEADER_KEY, [])
         existing_cookie = None
         for cookie in cookies:
@@ -417,8 +412,6 @@ class CookieJar(dict):
             ):
                 self.headers.add(self.HEADER_KEY, cookie)
             elif existing_cookie is None:
-                # Keep a snapshot of the cookie-to-be-deleted
-                # for reference when creating the deletion cookie
                 existing_cookie = cookie
         # This should be removed in v24.3
         try:
@@ -541,9 +534,7 @@ class Cookie(dict):
                     "Cannot set host_prefix on a cookie without secure=True"
                 )
             if path != "/":
-                raise ServerError(
-                    "Cannot set host_prefix on a cookie unless path='/'"
-                )
+                raise ServerError("Cannot set host_prefix on a cookie unless path='/'")
             if domain:
                 raise ServerError(
                     "Cannot set host_prefix on a cookie with a defined domain"
@@ -645,9 +636,7 @@ class Cookie(dict):
         """Format as a Set-Cookie header value."""
         output = ["%s=%s" % (self.key, _quote(self.value))]
         key_index = list(self._keys)
-        for key, value in sorted(
-            self.items(), key=lambda x: key_index.index(x[0])
-        ):
+        for key, value in sorted(self.items(), key=lambda x: key_index.index(x[0])):
             if value is not None and value is not False:
                 if key == "max-age":
                     try:

--- a/sanic/cookies/response.py
+++ b/sanic/cookies/response.py
@@ -534,7 +534,9 @@ class Cookie(dict):
                     "Cannot set host_prefix on a cookie without secure=True"
                 )
             if path != "/":
-                raise ServerError("Cannot set host_prefix on a cookie unless path='/'")
+                raise ServerError(
+                    "Cannot set host_prefix on a cookie unless path='/'"
+                )
             if domain:
                 raise ServerError(
                     "Cannot set host_prefix on a cookie with a defined domain"
@@ -636,7 +638,9 @@ class Cookie(dict):
         """Format as a Set-Cookie header value."""
         output = ["%s=%s" % (self.key, _quote(self.value))]
         key_index = list(self._keys)
-        for key, value in sorted(self.items(), key=lambda x: key_index.index(x[0])):
+        for key, value in sorted(
+            self.items(), key=lambda x: key_index.index(x[0])
+        ):
             if value is not None and value is not False:
                 if key == "max-age":
                     try:

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -427,20 +427,18 @@ def test_cookie_jar_delete_existing_nonsecure_cookie_bad_prefix():
     jar.add_cookie(
         "foo", "test", secure=False, domain="example.com", samesite="Strict"
     )
-    jar.delete_cookie(
-        "foo",
-        domain="example.com",
-        secure=False,
-        secure_prefix=True,
-        host_prefix=True,
-    )  # noqa
-
-    encoded = [cookie.encode("ascii") for cookie in jar.cookies]
-    # Deletion cookie has secure_prefix and host_prefix, but original cookie
-    # is not secure so ignore those invalid options on delete cookie.
-    assert encoded == [
-        b'foo=""; Path=/; Domain=example.com; Max-Age=0; SameSite=Strict',
-    ]
+    message = (
+        "Cannot set host_prefix on a cookie without "
+        "path='/', domain=None, and secure=True"
+    )
+    with pytest.raises(ServerError, match=message):
+        jar.delete_cookie(
+            "foo",
+            domain="example.com",
+            secure=False,
+            secure_prefix=True,
+            host_prefix=True,
+        )
 
 
 def test_cookie_jar_old_school_delete_encode():

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -380,6 +380,69 @@ def test_cookie_jar_delete_cookie_encode():
     ]
 
 
+def test_cookie_jar_delete_nonsecure_cookie():
+    headers = Header()
+    jar = CookieJar(headers)
+    jar.delete_cookie("foo", domain="example.com", secure=False)
+
+    encoded = [cookie.encode("ascii") for cookie in jar.cookies]
+    assert encoded == [
+        b'foo=""; Path=/; Domain=example.com; Max-Age=0',
+    ]
+
+
+def test_cookie_jar_delete_existing_cookie():
+    headers = Header()
+    jar = CookieJar(headers)
+    jar.add_cookie(
+        "foo", "test", secure=True, domain="example.com", samesite="Strict"
+    )
+    jar.delete_cookie("foo", domain="example.com", secure=True)
+
+    encoded = [cookie.encode("ascii") for cookie in jar.cookies]
+    # deletion cookie contains samesite=Strict as was in original cookie
+    assert encoded == [
+        b'foo=""; Path=/; Domain=example.com; Max-Age=0; SameSite=Strict; Secure',
+    ]
+
+
+def test_cookie_jar_delete_existing_nonsecure_cookie():
+    headers = Header()
+    jar = CookieJar(headers)
+    jar.add_cookie(
+        "foo", "test", secure=False, domain="example.com", samesite="Strict"
+    )
+    jar.delete_cookie("foo", domain="example.com", secure=False)
+
+    encoded = [cookie.encode("ascii") for cookie in jar.cookies]
+    # deletion cookie contains samesite=Strict as was in original cookie
+    assert encoded == [
+        b'foo=""; Path=/; Domain=example.com; Max-Age=0; SameSite=Strict',
+    ]
+
+
+def test_cookie_jar_delete_existing_nonsecure_cookie_bad_prefix():
+    headers = Header()
+    jar = CookieJar(headers)
+    jar.add_cookie(
+        "foo", "test", secure=False, domain="example.com", samesite="Strict"
+    )
+    jar.delete_cookie(
+        "foo",
+        domain="example.com",
+        secure=False,
+        secure_prefix=True,
+        host_prefix=True,
+    )  # noqa
+
+    encoded = [cookie.encode("ascii") for cookie in jar.cookies]
+    # Deletion cookie has secure_prefix and host_prefix, but original cookie
+    # is not secure so ignore those invalid options on delete cookie.
+    assert encoded == [
+        b'foo=""; Path=/; Domain=example.com; Max-Age=0; SameSite=Strict',
+    ]
+
+
 def test_cookie_jar_old_school_delete_encode():
     headers = Header()
     jar = CookieJar(headers)


### PR DESCRIPTION
Add ability to create a non-secure delete-cookie.
Also re-use existing cookie properties where possible if deleting a cookie that is already known in the response headers. Sanity-check and correct deletion cookie's `secure_prefix` and `host_prefix` based on the value of `secure` bool.

Add tests for these three things. (they were failing before the fix, passing after the fix).
Fixes #2972 