### PR TITLE
Fixed `mixins.startup.serve` UnboundLocalError.

### DIFF
--- a/sanic/mixins/startup.py
+++ b/sanic/mixins/startup.py
@@ -1033,6 +1033,7 @@ class StartupMixin(metaclass=SanicMeta):
 
         socks = []
         sync_manager = Manager()
+        worker_state: Mapping[str, Any] = {"state": "NONE"}
         setup_ext(primary)
         exit_code = 0
         try:
@@ -1056,7 +1057,7 @@ class StartupMixin(metaclass=SanicMeta):
             ]
             primary_server_info.settings["run_multiple"] = True
             monitor_sub, monitor_pub = Pipe(True)
-            worker_state: Mapping[str, Any] = sync_manager.dict()
+            worker_state = sync_manager.dict()
             kwargs: Dict[str, Any] = {
                 **primary_server_info.settings,
                 "monitor_publisher": monitor_pub,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 """
 Sanic
 """
+
 import codecs
 import os
 import re
@@ -59,7 +60,9 @@ def str_to_bool(val: str) -> bool:
 
 with open_local(["sanic", "__version__.py"], encoding="latin1") as fp:
     try:
-        version = re.findall(r"^__version__ = \"([^']+)\"\r?$", fp.read(), re.M)[0]
+        version = re.findall(
+            r"^__version__ = \"([^']+)\"\r?$", fp.read(), re.M
+        )[0]
     except IndexError:
         raise RuntimeError("Unable to determine version.")
 
@@ -94,7 +97,9 @@ setup_kwargs = {
     "entry_points": {"console_scripts": ["sanic = sanic.__main__:main"]},
 }
 
-env_dependency = '; sys_platform != "win32" ' 'and implementation_name == "cpython"'
+env_dependency = (
+    '; sys_platform != "win32" ' 'and implementation_name == "cpython"'
+)
 ujson = "ujson>=1.35" + env_dependency
 uvloop = "uvloop>=0.15.0" + env_dependency
 types_ujson = "types-ujson" + env_dependency


### PR DESCRIPTION
Fixes https://github.com/sanic-org/sanic/issues/2985

the `finally` block in `mixins.serve` references a variable that is only defined in the `try` block. This results in a `UnboundLocalError` within the `finally` block.