### PR TITLE
Fix SanicException `quiet` attribute handling when set to False

### DIFF
--- a/sanic/exceptions.py
+++ b/sanic/exceptions.py
@@ -72,7 +72,11 @@ class SanicException(Exception):
         status_code = status_code or getattr(
             self.__class__, "status_code", None
         )
-        quiet = quiet or getattr(self.__class__, "quiet", None)
+        quiet = (
+            quiet
+            if quiet is not None
+            else getattr(self.__class__, "quiet", None)
+        )
         headers = headers or getattr(self.__class__, "headers", {})
         if message is None:
             message = self.message

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -417,6 +417,21 @@ def test_exception_message_attribute():
     assert SanicException("").message == ""
 
 
+def test_exception_quiet_attribute():
+    class SilentException(SanicException):
+        quiet = True
+
+    class NoisyException(SanicException):
+        quiet = False
+
+    assert SilentException().quiet
+    assert not NoisyException().quiet
+    assert SilentException(quiet=True).quiet
+    assert NoisyException(quiet=True).quiet
+    assert not SilentException(quiet=False).quiet
+    assert not NoisyException(quiet=False).quiet
+
+
 def test_request_middleware_exception_on_404(app: Sanic):
     """See https://github.com/sanic-org/sanic/issues/2950"""
     counter = count()


### PR DESCRIPTION
Fixes an issue where the `quiet` attribute in `SanicException` would default to the class attribute when set to `False`. This occurs when the subclass `quiet` attribute is `True`. The fix ensures only `None` triggers the fallback.