### PR TITLE
Fix incompatible type annotation of `get` method in the `HTTPMethodView` class

### DIFF
--- a/sanic/views.py
+++ b/sanic/views.py
@@ -145,7 +145,7 @@ class HTTPMethodView:
     def dispatch_request(self, request: Request, *args, **kwargs):
         """Dispatch request to appropriate handler method."""
         method = request.method.lower()
-        handler = getattr(self, method)
+        handler = getattr(self, method, None)
 
         if not handler and method == "head":
             handler = getattr(self, "get")

--- a/sanic/views.py
+++ b/sanic/views.py
@@ -115,8 +115,6 @@ class HTTPMethodView:
         to `"/v"`.
     """
 
-    get: Optional[Callable[..., Any]]
-
     decorators: List[Callable[[Callable[..., Any]], Callable[..., Any]]] = []
 
     def __init_subclass__(
@@ -146,9 +144,11 @@ class HTTPMethodView:
 
     def dispatch_request(self, request: Request, *args, **kwargs):
         """Dispatch request to appropriate handler method."""
-        handler = getattr(self, request.method.lower(), None)
-        if not handler and request.method == "HEAD":
-            handler = self.get
+        method = request.method.lower()
+        handler = getattr(self, method)
+
+        if not handler and method == "head":
+            handler = getattr(self, "get")
         if not handler:
             # The router will never allow us to get here, but this is
             # included as a fallback and for completeness.


### PR DESCRIPTION
Resolves #2916

Use `getattr` to try getting the `get` handler to avoid the typing annotation incompatibility issue.