### PR TITLE
Custom commands

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -74,6 +74,7 @@ from sanic.http import Stage
 from sanic.log import LOGGING_CONFIG_DEFAULTS, error_logger, logger
 from sanic.logging.setup import setup_logging
 from sanic.middleware import Middleware, MiddlewareLocation
+from sanic.mixins.commands import CommandMixin
 from sanic.mixins.listeners import ListenerEvent
 from sanic.mixins.startup import StartupMixin
 from sanic.mixins.static import StaticHandleMixin
@@ -119,6 +120,7 @@ class Sanic(
     StaticHandleMixin,
     BaseSanic,
     StartupMixin,
+    CommandMixin,
     metaclass=TouchUpMeta,
 ):
     """The main application instance
@@ -189,6 +191,7 @@ class Sanic(
         "_blueprint_order",
         "_delayed_tasks",
         "_ext",
+        "_future_commands",
         "_future_exceptions",
         "_future_listeners",
         "_future_middleware",

--- a/sanic/app.py
+++ b/sanic/app.py
@@ -1672,14 +1672,15 @@ class Sanic(
         name: Optional[str] = None,
         register: bool = True,
     ) -> Task:
+        tsk: Task = task
         if not isinstance(task, Future):
             prepped = cls._prep_task(task, app, loop)
-            task = loop.create_task(prepped, name=name)
+            tsk = loop.create_task(prepped, name=name)
 
         if name and register:
-            app._task_registry[name] = task
+            app._task_registry[name] = tsk
 
-        return task
+        return tsk
 
     @staticmethod
     async def dispatch_delayed_tasks(
@@ -1708,7 +1709,7 @@ class Sanic(
     async def run_delayed_task(
         app: Sanic,
         loop: AbstractEventLoop,
-        task: Task[Any],
+        task: Union[Future[Any], Task[Any], Awaitable[Any]],
     ) -> None:
         """Executes a delayed task within the context of a given app and loop.
 

--- a/sanic/base/root.py
+++ b/sanic/base/root.py
@@ -4,6 +4,7 @@ from typing import Any, Optional
 
 from sanic.base.meta import SanicMeta
 from sanic.exceptions import SanicException
+from sanic.mixins.commands import CommandMixin
 from sanic.mixins.exceptions import ExceptionMixin
 from sanic.mixins.listeners import ListenerMixin
 from sanic.mixins.middleware import MiddlewareMixin
@@ -22,6 +23,7 @@ class BaseSanic(
     ListenerMixin,
     ExceptionMixin,
     SignalMixin,
+    CommandMixin,
     metaclass=SanicMeta,
 ):
     __slots__ = ("name",)

--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -97,6 +97,7 @@ class Blueprint(BaseSanic):
 
     __slots__ = (
         "_apps",
+        "_future_commands",
         "_future_routes",
         "_future_statics",
         "_future_middleware",

--- a/sanic/blueprints.py
+++ b/sanic/blueprints.py
@@ -511,6 +511,11 @@ class Blueprint(BaseSanic):
                 ),
             )
 
+        if self._future_commands:
+            raise SanicException(
+                "Registering commands with blueprints is not supported."
+            )
+
     async def dispatch(self, *args, **kwargs):
         """Dispatch a signal event
 

--- a/sanic/cli/arguments.py
+++ b/sanic/cli/arguments.py
@@ -68,6 +68,21 @@ class GeneralGroup(Group):
             ),
         )
 
+        self.container.add_argument(
+            "action",
+            nargs="?",
+            default="serve",
+            choices=[
+                "serve",
+                "exec",
+            ],
+            help=(
+                "Action to perform.\n"
+                "\tserve: Run the Sanic app\n"
+                "\texec: Execute a command in the Sanic app context\n"
+            ),
+        )
+
 
 class ApplicationGroup(Group):
     name = "Application"

--- a/sanic/cli/executor.py
+++ b/sanic/cli/executor.py
@@ -1,0 +1,90 @@
+import shutil
+
+from argparse import ArgumentParser
+from asyncio import run
+from inspect import signature
+from typing import Callable, Dict, List
+
+from sanic import Sanic
+from sanic.application.logo import get_logo
+from sanic.cli.base import (
+    SanicArgumentParser,
+    SanicHelpFormatter,
+)
+
+
+def make_executor_parser(parser: ArgumentParser) -> None:
+    parser.add_argument(
+        "command",
+        help="Command to execute",
+    )
+
+
+class ExecutorSubParser(ArgumentParser):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not self.description:
+            self.description = ""
+        self.description = get_logo(True) + self.description
+
+
+class Executor:
+    def __init__(self, app: Sanic, kwargs: dict) -> None:
+        self.app = app
+        self.kwargs = kwargs
+        self.commands = self._make_commands()
+        self.parser = self._make_parser()
+
+    def run(self, command: str, args: List[str]) -> None:
+        if command == "exec":
+            args = ["--help"]
+        parsed_args = self.parser.parse_args(args)
+        if command not in self.commands:
+            raise ValueError(f"Unknown command: {command}")
+        parsed_kwargs = vars(parsed_args)
+        parsed_kwargs.pop("command")
+        run(self.commands[command](**parsed_kwargs))
+
+    def _make_commands(self) -> Dict[str, Callable]:
+        commands = {c.name: c.func for c in self.app._future_commands}
+        return commands
+
+    def _make_parser(self) -> SanicArgumentParser:
+        width = shutil.get_terminal_size().columns
+        parser = SanicArgumentParser(
+            prog="sanic",
+            description=get_logo(True),
+            formatter_class=lambda prog: SanicHelpFormatter(
+                prog,
+                max_help_position=36 if width > 96 else 24,
+                indent_increment=4,
+                width=None,
+            ),
+        )
+
+        subparsers = parser.add_subparsers(
+            dest="command",
+            title="  Commands",
+            parser_class=ExecutorSubParser,
+        )
+        for command in self.app._future_commands:
+            sub = subparsers.add_parser(
+                command.name,
+                help=command.func.__doc__ or f"Execute {command.name}",
+                formatter_class=SanicHelpFormatter,
+            )
+            self._add_arguments(sub, command.func)
+
+        return parser
+
+    def _add_arguments(self, parser: ArgumentParser, func: Callable) -> None:
+        sig = signature(func)
+        for param in sig.parameters.values():
+            kwargs = {}
+            if param.default is not param.empty:
+                kwargs["default"] = param.default
+            parser.add_argument(
+                f"--{param.name}",
+                help=param.annotation,
+                **kwargs,
+            )

--- a/sanic/mixins/commands.py
+++ b/sanic/mixins/commands.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from functools import wraps
+from inspect import isawaitable
+from typing import Callable, Optional, Set, Union
+
+from sanic.base.meta import SanicMeta
+from sanic.models.futures import FutureCommand
+
+
+class CommandMixin(metaclass=SanicMeta):
+    def __init__(self, *args, **kwargs) -> None:
+        self._future_commands: Set[FutureCommand] = set()
+
+    def command(
+        self, maybe_func: Optional[Callable] = None, *, name: str = ""
+    ) -> Union[Callable, Callable[[Callable], Callable]]:
+        def decorator(f):
+            @wraps(f)
+            async def decorated_function(*args, **kwargs):
+                response = f(*args, **kwargs)
+                if isawaitable(response):
+                    response = await response
+                return response
+
+            self._future_commands.add(
+                FutureCommand(name or f.__name__, decorated_function)
+            )
+            return decorated_function
+
+        return decorator(maybe_func) if maybe_func else decorator

--- a/sanic/mixins/static.py
+++ b/sanic/mixins/static.py
@@ -179,15 +179,16 @@ class StaticHandleMixin(metaclass=SanicMeta):
         Register a static directory handler with Sanic by adding a route to the
         router and registering a handler.
         """
+        file_or_directory: PathLike
 
         if isinstance(static.file_or_directory, bytes):
-            file_or_directory = static.file_or_directory.decode("utf-8")
+            file_or_directory = Path(static.file_or_directory.decode("utf-8"))
         elif isinstance(static.file_or_directory, PurePath):
-            file_or_directory = str(static.file_or_directory)
-        elif not isinstance(static.file_or_directory, str):
-            raise ValueError("Invalid file path string.")
-        else:
             file_or_directory = static.file_or_directory
+        elif isinstance(static.file_or_directory, str):
+            file_or_directory = Path(static.file_or_directory)
+        else:
+            raise ValueError("Invalid file path string.")
 
         uri = static.uri
         name = static.name

--- a/sanic/mixins/static.py
+++ b/sanic/mixins/static.py
@@ -225,7 +225,7 @@ class StaticHandleMixin(metaclass=SanicMeta):
         _handler = wraps(self._static_request_handler)(
             partial(
                 self._static_request_handler,
-                file_or_directory=file_or_directory,
+                file_or_directory=str(file_or_directory),
                 use_modified_since=static.use_modified_since,
                 use_content_range=static.use_content_range,
                 stream_large_files=static.stream_large_files,

--- a/sanic/models/futures.py
+++ b/sanic/models/futures.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, Iterable, List, NamedTuple, Optional, Union
+from typing import Callable, Dict, Iterable, List, NamedTuple, Optional, Union
 
 from sanic.handlers.directory import DirectoryHandler
 from sanic.models.handler_types import (
@@ -70,3 +70,8 @@ class FutureSignal(NamedTuple):
 
 
 class FutureRegistry(set): ...
+
+
+class FutureCommand(NamedTuple):
+    name: str
+    func: Callable

--- a/tests/fake/server.py
+++ b/tests/fake/server.py
@@ -52,3 +52,18 @@ def create_app_with_args(args):
         logger.info(f"target={args.target}")
 
     return app
+
+
+@app.command
+async def foo(one, two: str, three: str = "..."):
+    logger.info(f"FOO {one=} {two=} {three=}")
+
+
+@app.command
+def bar():
+    logger.info("BAR")
+
+
+@app.command(name="qqq")
+async def baz():
+    logger.info("BAZ")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -369,3 +369,38 @@ def test_server_run_with_repl(caplog, capsys):
 
     run()
     assert record in caplog.record_tuples
+
+
+def test_command_no_args(caplog):
+    args = ["fake.server.app", "exec", "foo"]
+    with patch("sys.argv", ["sanic", *args]):
+        lines = capture(args, caplog)
+    assert "FOO one=None two=None three='...'" in lines
+
+
+def test_command_with_args(caplog):
+    args = [
+        "fake.server.app",
+        "exec",
+        "foo",
+        "--one=1",
+        "--two=2",
+        "--three=3",
+    ]
+    with patch("sys.argv", ["sanic", *args]):
+        lines = capture(args, caplog)
+    assert "FOO one='1' two='2' three='3'" in lines
+
+
+def test_command_with_sync_handler(caplog):
+    args = ["fake.server.app", "exec", "bar"]
+    with patch("sys.argv", ["sanic", *args]):
+        lines = capture(args, caplog)
+    assert "BAR" in lines
+
+
+def test_command_with_renamed_command(caplog):
+    args = ["fake.server.app", "exec", "qqq"]
+    with patch("sys.argv", ["sanic", *args]):
+        lines = capture(args, caplog)
+    assert "BAZ" in lines


### PR DESCRIPTION
This adds the ability to add commands to the `sanic` CLI.

```python
@app.command
async def foo(one, two: str, three: str = "..."):
    logger.info(f"FOO {one=} {two=} {three=}")


@app.command
def bar():
    logger.info("BAR")


@app.command(name="qqq")
async def baz():
    logger.info("BAZ")
```

These are invoked using

```sh
sanic server:app exec <command> [--arg=value]
```