### PR TITLE
Fixes sanic_ext - openapi component documentation

### DIFF
--- a/guide/content/en/plugins/sanic-ext/openapi/decorators.md
+++ b/guide/content/en/plugins/sanic-ext/openapi/decorators.md
@@ -441,7 +441,7 @@ Pydantic models have the ability to [generate OpenAPI schema](https://pydantic-d
     from sanic_ext import validate, openapi
     from pydantic import BaseModel, Field
 
-    @openapi.component
+    @openapi.component()
     class Item(BaseModel):
         name: str
         description: str = None
@@ -456,7 +456,7 @@ Pydantic models have the ability to [generate OpenAPI schema](https://pydantic-d
     @app.get("/")
     @openapi.definition(
         body={
-            "application/json": ItemList.schema(
+            "application/json": ItemList.model_json_schema(
                 ref_template="#/components/schemas/{model}"
             )
         },


### PR DESCRIPTION
The openapi component documentation is outdated. As of right now, for pydantic BaseModels, we first of all define the component as 
_openapi.component()_ -> Only this will return the wrap function

further we generate the json_schema using
BaseModel.model_json_schema
rather than _BaseModel.schema_