### PR TITLE
fix(startup): Differentiate between None vs. 0 port

### DIFF
--- a/sanic/mixins/startup.py
+++ b/sanic/mixins/startup.py
@@ -892,7 +892,8 @@ class StartupMixin(metaclass=SanicMeta):
             Tuple[str, int]: Tuple containing the host and port
         """  # noqa: E501
         host = host or "127.0.0.1"
-        port = port or (8443 if (version == 3 or auto_tls) else 8000)
+        if port is None:
+            port = 8443 if (version == 3 or auto_tls) else 8000
         return host, port
 
     @classmethod


### PR DESCRIPTION
I'm currently developing a sanic application which should support service discovery.
In order to have a degree of freedom in choosing how to run sanic in this context, I'm in need of random ports to be chosen by the operating system.
Intentionally, at least according to the docs, this should be possible by simply setting port either to `None` or `0`.
Though, I stumbled upon the `mixin/startup` code which is in case of a tls start up fixing this to `8443` or `8000` in both occasions, since coalescing port like this
`port = port or 8443 if (version == 3 or auto_tls) else 8000`

will be in both cases (`0` and `None`) fallback to this term `8443 if (version == 3 or auto_tls) else 8000`

Since I do not want to break anything, I suggest changing this to the following behaviour:

In case of `port=None` persist the logic as is
In case of `port=0` let the OS handle choosing a port for us (which would be a random port)

Feedback is very much welcome and I'm open for alternative approaches.
If we could enable this one way or the other I'd very much appreciate it.

(Thank you for this awesome framework :heart: )