### PR TITLE
Fix 'how we built sanic' sidebar link

### DIFF
--- a/guide/webapp/display/layouts/elements/sidebar.py
+++ b/guide/webapp/display/layouts/elements/sidebar.py
@@ -24,7 +24,7 @@ def _menu_items(request: Request) -> list[Builder]:
         ),
         E.li("How we ").a(
             "built this site w/ Sanic",
-            href="/{request.ctx.language}/built-with-sanic.html",
+            href=f"/{request.ctx.language}/built-with-sanic.html",
         ),
         E.li("The ").a(
             "Awesome Sanic",


### PR DESCRIPTION
This fixes this link:

![afbeelding](https://github.com/user-attachments/assets/31f5b14e-483e-4229-9dac-ed5002156d83)
