### PR TITLE
Fix shutdown procedure after signal

### DIFF
--- a/sanic/worker/manager.py
+++ b/sanic/worker/manager.py
@@ -293,7 +293,7 @@ class WorkerManager:
         while True:
             try:
                 cycle = self._poll_monitor()
-                if cycle is MonitorCycle.BREAK:
+                if self._shutting_down or cycle is MonitorCycle.BREAK:
                     break
                 elif cycle is MonitorCycle.CONTINUE:
                     continue
@@ -314,7 +314,7 @@ class WorkerManager:
             "If this problem persists, please check out the documentation "
             "https://sanic.dev/en/guide/deployment/manager.html#worker-ack."
         )
-        while not self._all_workers_ack():
+        while not self._shutting_down and not self._all_workers_ack():
             if self.monitor_subscriber.poll(0.1):
                 monitor_msg = self.monitor_subscriber.recv()
                 if monitor_msg != "__TERMINATE_EARLY__":


### PR DESCRIPTION
When a termination signal was received (SIGTERM/SIGINT) while worker was initiating, manager fell into a deadloop (?) reading and writing None from/into a monitor sub/pub pipe.

After the change, I am unable to reproduce the case given in https://github.com/sanic-org/sanic/issues/2997:

    $ SANIC_CUSTOM_DELAY=100 python3 server.py
    ....
    KeyboardInterrupt
    Main  10:56:16 INFO:   Server Stopped
    $ echo $?
    0

Please let me know if this is okey, or still some work needed prior merging.
How to integrate this into main branch and both LTS releases?