### PR TITLE
feat: add SERVER_NAME to passthru config if specified in app config

### DIFF
--- a/sanic/mixins/startup.py
+++ b/sanic/mixins/startup.py
@@ -1078,7 +1078,10 @@ class StartupMixin(metaclass=SanicMeta):
                 "shared_ctx": app.shared_ctx.__dict__,
             }
             if app.config.SERVER_NAME:
-                kwargs["passthru"]["config"]["SERVER_NAME"] = app.config.SERVER_NAME
+                if app.config.SERVER_NAME:
+                    kwargs["passthru"]["config"]["SERVER_NAME"] = (
+                        app.config.SERVER_NAME
+                    )
             for app in apps:
                 kwargs["server_info"][app.name] = []
                 for server_info in app.state.server_info:

--- a/sanic/mixins/startup.py
+++ b/sanic/mixins/startup.py
@@ -1077,6 +1077,8 @@ class StartupMixin(metaclass=SanicMeta):
                 },
                 "shared_ctx": app.shared_ctx.__dict__,
             }
+            if app.config.SERVER_NAME:
+                kwargs["passthru"]["config"]["SERVER_NAME"] = app.config.SERVER_NAME
             for app in apps:
                 kwargs["server_info"][app.name] = []
                 for server_info in app.state.server_info:


### PR DESCRIPTION
This does not work as expected:

```python
@app.main_process_start
async def update_server_name(app, loop):
    some_url = some_reason()
    if some_url:
        app.update_config({"SERVER_NAME": some_url})
```

## Problem
I would have expected my SERVER_NAME update to have propagated to workers, especially since doing this on `main_process_start`, but this is not the case. Because I have SANIC_SERVER_NAME env var set to some different value, all my workers still take that value, even though I just updated it with a new value.

## Solution
With this PR, code above now works, and I can optionally change my SERVER_NAME at `main_process_start` and all my workers will have the correct SERVER_NAME.