### PR TITLE
silent on RuntimeError when write_eof

### DIFF
--- a/sanic/server/websockets/impl.py
+++ b/sanic/server/websockets/impl.py
@@ -419,7 +419,10 @@ class WebsocketImplProtocol:
                 websockets_logger.debug(
                     "Websocket half-closing TCP connection"
                 )
-                self.io_proto.transport.write_eof()
+                try:
+                    self.io_proto.transport.write_eof()
+                except RuntimeError:
+                    ...
                 if self.connection_lost_waiter:
                     if await self.wait_for_connection_lost(timeout=0):
                         return


### PR DESCRIPTION
Current websocket will raise an RuntimeError because of uvloop

```
Error closing websocket connection
Traceback (most recent call last):
  File "/app/.venv/lib/python3.12/site-packages/sanic/server/websockets/impl.py", line 422, in auto_close_connection
    self.io_proto.transport.write_eof()
  File "uvloop/handles/stream.pyx", line 703, in uvloop.loop.UVStream.write_eof
  File "uvloop/handles/handle.pyx", line 159, in uvloop.loop.UVHandle._ensure_alive
RuntimeError: unable to perform operation on <TCPTransport closed=True reading=False 0x563198ffc650>; the handler is closed
```

The exception could be caught and discarded just like what the websockets library does: https://github.com/python-websockets/websockets/issues/1072