### PR TITLE
feat: Add automatic charset=UTF-8 to text content types

### DIFF
--- a/sanic/mixins/static.py
+++ b/sanic/mixins/static.py
@@ -1,7 +1,6 @@
 from collections.abc import Sequence
 from email.utils import formatdate
 from functools import partial, wraps
-from mimetypes import guess_type
 from os import PathLike, path
 from pathlib import Path, PurePath
 from typing import Optional, Union
@@ -11,7 +10,6 @@ from sanic_routing.route import Route
 
 from sanic.base.meta import SanicMeta
 from sanic.compat import stat_async
-from sanic.constants import DEFAULT_HTTP_CONTENT_TYPE
 from sanic.exceptions import FileNotFound, HeaderNotFound, RangeNotSatisfiable
 from sanic.handlers import ContentRangeHandler
 from sanic.handlers.directory import DirectoryHandler
@@ -20,6 +18,7 @@ from sanic.mixins.base import BaseMixin
 from sanic.models.futures import FutureStatic
 from sanic.request import Request
 from sanic.response import HTTPResponse, file, file_stream, validate_file
+from sanic.response.convenience import guess_content_type
 
 
 class StaticMixin(BaseMixin, metaclass=SanicMeta):
@@ -300,11 +299,7 @@ class StaticHandleMixin(metaclass=SanicMeta):
                         headers.update(_range.headers)
 
             if "content-type" not in headers:
-                content_type = (
-                    content_type
-                    or guess_type(file_path)[0]
-                    or DEFAULT_HTTP_CONTENT_TYPE
-                )
+                content_type = content_type or guess_content_type(file_path)
 
                 if "charset=" not in content_type and (
                     content_type.startswith("text/")

--- a/sanic/response/convenience.py
+++ b/sanic/response/convenience.py
@@ -290,12 +290,14 @@ async def file(
         else:
             out_stream = await f.read()
 
-    mime_type = mime_type or guess_type(filename)[0] or "text/plain"
+    content_type = mime_type or guess_content_type(
+        filename, fallback="text/plain"
+    )
     return HTTPResponse(
         body=out_stream,
         status=status,
         headers=headers,
-        content_type=mime_type,
+        content_type=content_type,
     )
 
 
@@ -395,3 +397,16 @@ async def file_stream(
         headers=headers,
         content_type=mime_type,
     )
+
+
+def guess_content_type(
+    file_path: Union[str, PurePath],
+    fallback: str = DEFAULT_HTTP_CONTENT_TYPE,
+) -> str:
+    """Guess the content type (rather than MIME only) by the file extension."""
+    mediatype = guess_type(file_path)[0]
+    if mediatype is None:
+        return fallback
+    if mediatype.startswith("text/"):
+        return f"{mediatype}; charset=UTF-8"
+    return mediatype

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1002,3 +1002,30 @@ def test_stream_response_with_default_headers(app: Sanic):
     assert response.text == "foo"
     assert response.headers["Transfer-Encoding"] == "chunked"
     assert response.headers["Content-Type"] == "text/csv"
+
+
+@pytest.mark.parametrize(
+    "file_name,expected_content_type",
+    [
+        ("decode me.txt", "text/plain; charset=UTF-8"),
+        ("test.html", "text/html; charset=UTF-8"),
+        ("python.png", "image/png"),
+        ("test.file", "application/octet-stream"),
+    ],
+)
+def test_file_response_content_type_with_charset(
+    app: Sanic, file_name, expected_content_type, static_file_directory
+):
+    """Test that file responses automatically include charset for text."""
+    @app.route("/files/<filename>", methods=["GET"])
+    def file_route(request, filename):
+        file_path = os.path.join(static_file_directory, filename)
+        file_path = os.path.abspath(unquote(file_path))
+        return file(file_path)
+
+    request, response = app.test_client.get(f"/files/{file_name}")
+    assert response.status == 200
+    assert response.headers["Content-Type"] == expected_content_type
+
+
+@pytest.mark.parametrize("file_name", ["test.file", "decode me.txt"])

--- a/tests/test_response_file.py
+++ b/tests/test_response_file.py
@@ -4,7 +4,7 @@ from logging import INFO
 import pytest
 
 from sanic.compat import Header
-from sanic.response.convenience import validate_file
+from sanic.response.convenience import guess_content_type, validate_file
 
 
 @pytest.mark.parametrize(
@@ -53,3 +53,40 @@ async def test_file_timestamp_validation(
     else:
         record = records[0]
         assert expected in record.message
+
+
+@pytest.mark.parametrize(
+    "file_path,expected",
+    (
+        ("test.html", "text/html; charset=UTF-8"),
+        ("test.txt", "text/plain; charset=UTF-8"),
+        ("test.css", "text/css; charset=UTF-8"),
+        ("test.js", "text/javascript; charset=UTF-8"),
+        ("test.xml", "application/xml"),
+        ("test.csv", "text/csv; charset=UTF-8"),
+        ("test.json", "application/json"),
+        ("test.pdf", "application/pdf"),
+        ("test.png", "image/png"),
+        ("test.jpg", "image/jpeg"),
+        ("test.unknown", "application/octet-stream"),
+        ("no_extension", "application/octet-stream"),
+    ),
+)
+def test_guess_content_type(file_path, expected):
+    """Test that guess_content_type correctly adds charset for text types."""
+    result = guess_content_type(file_path)
+    assert result == expected
+
+
+def test_guess_content_type_with_custom_fallback():
+    """Test that guess_content_type uses custom fallback for unknown types."""
+    result = guess_content_type("unknown.xyz", fallback="custom/type")
+    assert result == "custom/type"
+
+
+def test_guess_content_type_with_pathlib():
+    """Test that guess_content_type works with pathlib Path objects."""
+    from pathlib import Path
+
+    result = guess_content_type(Path("test.html"))
+    assert result == "text/html; charset=UTF-8"


### PR DESCRIPTION
Refactor content type handling to automatically append charset=UTF-8 to text/* MIME types when serving static files and file responses.

- Add new guess_content_type() utility function that wraps mimetypes.guess_type()
- Automatically append '; charset=UTF-8' to text content types
- Replace direct mimetypes.guess_type() usage with new utility
- Update static file serving and file() response functions to use new utility

Fix #2987