### PR TITLE
Fix WorkerManager.kill on Windows

### DIFF
--- a/sanic/worker/manager.py
+++ b/sanic/worker/manager.py
@@ -374,7 +374,8 @@ class WorkerManager:
             with suppress(ProcessLookupError):
                 try:
                     os.killpg(os.getpgid(process.pid), SIGKILL)
-                except OSError:
+                except (OSError, AttributeError):
+                    # AttributeError is for Windows, where there is no killpg
                     os.kill(process.pid, SIGKILL)
         raise ServerKilled
 


### PR DESCRIPTION
`WorkerManager.kill` was attempting to kill processes with `os.killpg`. This isn't available on Windows so there was a traceback every time it was called. This change just lets it fall back to the `os.kill` on Windows.

fix #3043 