### PR TITLE
Add DetailedConverter for advanced environment variable conversion

### DIFF
--- a/guide/content/en/guide/running/configuration.md
+++ b/guide/content/en/guide/running/configuration.md
@@ -203,6 +203,57 @@ If a value cannot be cast, it will default to a `str`.
     app = Sanic(..., config=Config(converters=[UUID]))
     ```
 
+#### Advanced Type Converters
+
+.. column::
+
+    For more sophisticated conversion logic that needs access to the full environment variable context, you can use `DetailedConverter`. This abstract base class provides access to the full environment variable key, the raw value, and the current config defaults.
+
+    This is useful when you need to:
+    - Cast values to the type of their defaults
+    - Perform validation based on the variable name pattern
+    - Use default values for fallback logic
+    - Access configuration context during conversion
+
+.. column::
+
+    ```python
+    from sanic.config import DetailedConverter
+
+    class DefaultsTypeCastingConverter(DetailedConverter):
+        def __call__(self, full_key: str, config_key: str, value: str, defaults: dict):
+            try:
+                if config_key in defaults:
+                    return type(defaults[config_key])(value)
+            except (ValueError, TypeError) as e:
+                raise TypeError(f"Configuration environment variable '{full_key}' type mismatch: expected"
+                                f" {type(defaults[config_key]).__name__}, got {type(value).__name__}") from e
+
+    app = Sanic(..., config=Config(converters=[DefaultsTypeCastingConverter()]))
+    ```
+
+.. column::
+
+    The `DetailedConverter.__call__` method receives four parameters:
+
+    - `full_key`: The full environment variable name with prefix (e.g., "SANIC_DATABASE_URL")
+    - `config_key`: The config key without prefix (e.g., "DATABASE_URL")
+    - `value`: The raw string value from the environment
+    - `defaults`: The current default configuration values
+
+.. column::
+
+    ```python
+    class ValidationConverter(DetailedConverter):
+        def __call__(self, full_key: str, config_key: str, value: str, defaults: dict):
+            if config_key.endswith('_PORT'):
+                port = int(value)
+                if not 1 <= port <= 65535:
+                    raise ValueError(f"Invalid port: {port}")
+                return port
+            raise ValueError  # Let other converters handle it
+    ```
+
 ## Builtin values
 
 | **Variable**              | **Default**      | **Description**                                                                                                                       |


### PR DESCRIPTION
Real life example.
We have an app that accepts hexadecimal prefixes (0–f) as a configuration parameter. To support environment-based configuration, we used Sanic’s built-in environment variable parsing by setting SANIC_PREFIX with values from 0 to f.

You can imagine my surprise when I saw this in one of 16 pods running our app:
`2025-07-30 08:14:23,108 [INFO] Beginning update for prefix: **False**`


```python
import os
import sanic
from sanic.config import Config
from sanic.config import DetailedConverter
from sanic.log import logger

DEFAULTS = {
    "CONFIG_STRING": str("abc"),
    "CONFIG_INT": int(123),
    "CONFIG_BOOL": bool(True),
}

class DefaultsTypeCastingConverter(DetailedConverter):
    def __call__(self, full_key: str, config_key: str, value: str, defaults: dict):
        try:
            if config_key in defaults:
                return type(defaults[config_key])(value)
        except (ValueError, TypeError) as e:
            raise TypeError(f"Configuration environment variable '{full_key}' type mismatch: expected"
                            f" {type(defaults[config_key]).__name__}, got {type(value).__name__}") from e

# Simulate environment variables for testing
os.environ["SANIC_CONFIG_STRING"] = "overridden_string"
os.environ["SANIC_CONFIG_INT"] = "456"
os.environ["SANIC_CONFIG_BOOL"] = "False"

# This would rise an error if uncommented, as it conflicts with its type in DEFAULTS
#os.environ["SANIC_CONFIG_INT"] = "i_am_definitely_not_an_int"

APP = sanic.Sanic("TestApp", config=sanic.Config(defaults=DEFAULTS, converters=[DefaultsTypeCastingConverter()]))
@APP.route("/")
async def a(request):
    return

# Print defaults (overridden) with their types
logger.warning("Sanic app initialized with overridden defaults:")
logger.warning("-" * 40)
for key, value in APP.config.items():
    if key in DEFAULTS:
        logger.warning(f"{key}: {value} (type: {type(value).__name__})")

if __name__ == "__main__":
    APP.run(host="127.0.0.1", port=8000, single_process=True)

```