### PR TITLE
Update str_to_bool function to include 'nope' as a valid false value

### DIFF
--- a/guide/content/en/guide/running/configuration.md
+++ b/guide/content/en/guide/running/configuration.md
@@ -187,7 +187,7 @@ When loading from environment variables, Sanic will attempt to cast the values t
 In regards to `bool`, the following _case insensitive_ values are allowed:
 
 - **`True`**: `y`, `yes`, `yep`, `yup`, `t`, `true`, `on`, `enable`, `enabled`, `1`
-- **`False`**: `n`, `no`, `f`, `false`, `off`, `disable`, `disabled`, `0`
+- **`False`**: `n`, `no`, `f`, `nope`, `false`, `off`, `disable`, `disabled`, `0`
 
 If a value cannot be cast, it will default to a `str`.
 

--- a/sanic/utils.py
+++ b/sanic/utils.py
@@ -18,7 +18,7 @@ def str_to_bool(val: str) -> bool:
         "true", "on", "enable", "enabled", "1"
     ) returns True.
     If val is in case insensitive (
-        "n", "no", "f", "false", "off", "disable", "disabled", "0"
+        "n", "no", "f", "nope", "false", "off", "disable", "disabled", "0"
     ) returns False.
     Else Raise ValueError."""
 
@@ -36,7 +36,9 @@ def str_to_bool(val: str) -> bool:
         "1",
     }:
         return True
-    elif val in {"n", "no", "f", "false", "off", "disable", "disabled", "0"}:
+    elif val in {
+        "n", "no", "f", "nope", "false", "off", "disable", "disabled", "0"
+    }:
         return False
     else:
         raise ValueError(f"Invalid truth value {val}")

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,17 @@ def str_to_bool(val: str) -> bool:
         "1",
     }:
         return True
-    elif val in {"n", "no", "f", "false", "off", "disable", "disabled", "0"}:
+    elif val in {
+        "n",
+        "no",
+        "f",
+        "nope",
+        "false",
+        "off",
+        "disable",
+        "disabled",
+        "0",
+    }:
         return False
     else:
         raise ValueError(f"Invalid truth value {val}")


### PR DESCRIPTION
Let’s keep things fair.
If we're parsing 'yup' and 'yep' as bool type True.
Definitely 'nope' belongs to bool type False.

Example:
```python
import os
import sanic

os.environ["SANIC_NOPE"] = "nope"

app = sanic.Sanic("Nope")

@app.route("/")
async def nope(request):
    return sanic.response.json({"NOPE IS": app.config.get("NOPE")}) # {NOPE IS: false}


if __name__ == "__main__":
    app.run()
```