### PR TITLE
Fix SSL configuration ignored for non-primary apps in multi-serve

### DIFF
--- a/sanic/mixins/startup.py
+++ b/sanic/mixins/startup.py
@@ -1098,11 +1098,19 @@ class StartupMixin(metaclass=SanicMeta):
             for app in apps:
                 kwargs["server_info"][app.name] = []
                 for server_info in app.state.server_info:
-                    server_info.settings = {
+                    # Convert SSL context to serializable dict form
+                    # so it can be passed through multiprocessing
+                    app_ssl = server_info.settings.get("ssl")
+                    filtered_settings = {
                         k: v
                         for k, v in server_info.settings.items()
                         if k not in ("main_start", "main_stop", "app", "ssl")
                     }
+                    if isinstance(app_ssl, SanicSSLContext):
+                        filtered_settings["ssl"] = app_ssl.sanic
+                    elif app_ssl is not None:
+                        filtered_settings["ssl"] = app_ssl
+                    server_info.settings = filtered_settings
                     kwargs["server_info"][app.name].append(server_info)
 
             ssl = kwargs.get("ssl")

--- a/sanic/worker/serve.py
+++ b/sanic/worker/serve.py
@@ -83,6 +83,18 @@ def worker_serve(
             for info in app.state.server_info:
                 info.settings["ssl"] = ssl
 
+        # Load per-app SSL for non-primary apps from their server_info settings
+        if server_info:
+            for si_app_name in server_info:
+                a = Sanic.get_app(si_app_name)
+                for info in a.state.server_info:
+                    info_ssl = info.settings.get("ssl")
+                    if info_ssl is not None and not isinstance(
+                        info_ssl, SSLContext
+                    ):
+                        cert_loader = a.certloader_class(info_ssl)
+                        info.settings["ssl"] = cert_loader.load(a)
+
         # When in a worker process, do some init
         worker_name = os.environ.get("SANIC_WORKER_NAME")
         if worker_name and worker_name.startswith(


### PR DESCRIPTION
## Description

Fixes #3131

When serving multiple apps via `Sanic.serve()`, the SSL configuration for non-primary apps was silently ignored — secondary apps were served over HTTP instead of HTTPS.

### Root Cause

The SSL configuration flow had a gap for non-primary apps:

1. **`Sanic.serve()`** stripped SSL from all apps' `server_info.settings` during serialization for multiprocessing (since `SSLContext` objects can't be pickled)
2. Only the primary app's SSL was passed as a global `kwargs["ssl"]`
3. **`worker_serve()`** only restored SSL to the primary app's server_info

### Fix

**In `startup.py`**: Instead of stripping SSL entirely, convert `SanicSSLContext` to its serializable dict form (`sanic` attribute) and keep it in each app's `server_info.settings`. Raw dict/string SSL values are passed through as-is.

**In `serve.py`**: After the existing primary-app SSL loading, iterate through all apps' server_info and load SSL contexts from any serialized SSL dicts that haven't been converted yet.

This preserves backward compatibility — the primary app still gets its SSL from the global kwarg, while non-primary apps now get theirs from their own server_info.