### PR TITLE
Assign datetime.replace() return value in validate_file

### DIFF
--- a/sanic/response/convenience.py
+++ b/sanic/response/convenience.py
@@ -187,7 +187,7 @@ async def validate_file(
             "Cannot compare tz-aware and tz-naive datetimes. To avoid "
             "this conflict Sanic is converting last_modified to UTC."
         )
-        last_modified.replace(tzinfo=timezone.utc)
+        last_modified = last_modified.replace(tzinfo=timezone.utc)
     elif (
         last_modified.utcoffset() is not None
         and if_modified_since.utcoffset() is None
@@ -196,7 +196,7 @@ async def validate_file(
             "Cannot compare tz-aware and tz-naive datetimes. To avoid "
             "this conflict Sanic is converting if_modified_since to UTC."
         )
-        if_modified_since.replace(tzinfo=timezone.utc)
+        if_modified_since = if_modified_since.replace(tzinfo=timezone.utc)
     if last_modified.timestamp() <= if_modified_since.timestamp():
         return HTTPResponse(status=304)
 


### PR DESCRIPTION
`validate_file()` calls `datetime.replace(tzinfo=timezone.utc)` to normalize tz-naive datetimes before comparing `last_modified` and `if_modified_since` timestamps. However, `datetime.replace()` returns a **new** datetime — it doesn't mutate in place. Since the return values aren't assigned back, both variables remain tz-naive after the "fix."

The practical effect: on any server not running in UTC, `last_modified.timestamp()` interprets the tz-naive datetime as local time while the tz-aware one is interpreted as UTC. This produces incorrect comparisons and breaks HTTP 304 Not Modified responses — either serving stale content or forcing unnecessary re-downloads depending on the timezone offset direction.
