### PR TITLE
Guard signal waiter set_result against already-done futures

### DIFF
--- a/sanic/signals.py
+++ b/sanic/signals.py
@@ -233,7 +233,8 @@ class SignalRouter(BaseRouter):
             for signal in signals:
                 for waiter in signal.ctx.waiters:
                     if waiter.matches(event, condition):
-                        waiter.future.set_result(dict(params))
+                        if not waiter.future.done():
+                            waiter.future.set_result(dict(params))
 
             for signal in signals:
                 requirements = signal.extra.requirements


### PR DESCRIPTION
In `SignalRouter.dispatch()`, `set_result` is called on signal waiter futures without first checking whether the future is already done. If multiple signals in the same dispatch batch match the same waiter, or if the future was cancelled by another task before the loop reaches it, `set_result` raises `asyncio.InvalidStateError`.

This unhandled exception aborts the entire signal dispatch loop, preventing subsequent signal handlers from executing. Adding a `future.done()` guard before `set_result` avoids the crash and ensures all matching signals are dispatched.
