### PR TITLE
fix: suppress Python 3.14 deprecation warnings for asyncio policy API (#3129)

### DIFF
--- a/sanic/app.py
+++ b/sanic/app.py
@@ -416,7 +416,7 @@ class Sanic(
         try:
             return get_running_loop()
         except RuntimeError:  # no cov
-            return asyncio.get_event_loop_policy().get_event_loop()
+            return asyncio.get_event_loop()
 
     # -------------------------------------------------------------------- #
     # Registration

--- a/sanic/server/loop.py
+++ b/sanic/server/loop.py
@@ -9,6 +9,15 @@ from sanic.log import error_logger
 from sanic.utils import str_to_bool
 
 
+# Python 3.14 deprecates the asyncio policy API (slated for removal in
+# Python 3.16). Match only the policy-related messages so other
+# DeprecationWarnings raised from asyncio are not hidden.
+_POLICY_DEPRECATION_MESSAGE = (
+    r"'asyncio\.((get|set)_event_loop_policy|\w*EventLoopPolicy)'"
+    r" is deprecated"
+)
+
+
 def try_use_uvloop() -> None:
     """Use uvloop instead of the default asyncio loop."""
     if OS_IS_WINDOWS:
@@ -48,7 +57,9 @@ def try_use_uvloop() -> None:
     with warnings.catch_warnings():
         if sys.version_info >= (3, 14):
             warnings.filterwarnings(
-                "ignore", category=DeprecationWarning, module="asyncio"
+                "ignore",
+                category=DeprecationWarning,
+                message=_POLICY_DEPRECATION_MESSAGE,
             )
         if not isinstance(
             asyncio.get_event_loop_policy(), uvloop.EventLoopPolicy
@@ -70,7 +81,9 @@ def try_windows_loop():
     with warnings.catch_warnings():
         if sys.version_info >= (3, 14):
             warnings.filterwarnings(
-                "ignore", category=DeprecationWarning, module="asyncio"
+                "ignore",
+                category=DeprecationWarning,
+                message=_POLICY_DEPRECATION_MESSAGE,
             )
         if not isinstance(
             asyncio.get_event_loop_policy(),

--- a/sanic/server/loop.py
+++ b/sanic/server/loop.py
@@ -1,4 +1,6 @@
 import asyncio
+import sys
+import warnings
 
 from os import getenv
 
@@ -43,8 +45,15 @@ def try_use_uvloop() -> None:
             "false."
         )
 
-    if not isinstance(asyncio.get_event_loop_policy(), uvloop.EventLoopPolicy):
-        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+    with warnings.catch_warnings():
+        if sys.version_info >= (3, 14):
+            warnings.filterwarnings(
+                "ignore", category=DeprecationWarning, module="asyncio"
+            )
+        if not isinstance(
+            asyncio.get_event_loop_policy(), uvloop.EventLoopPolicy
+        ):
+            asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
 
 def try_windows_loop():
@@ -58,7 +67,15 @@ def try_windows_loop():
         )
         return
 
-    if not isinstance(
-        asyncio.get_event_loop_policy(), asyncio.WindowsSelectorEventLoopPolicy
-    ):
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    with warnings.catch_warnings():
+        if sys.version_info >= (3, 14):
+            warnings.filterwarnings(
+                "ignore", category=DeprecationWarning, module="asyncio"
+            )
+        if not isinstance(
+            asyncio.get_event_loop_policy(),
+            asyncio.WindowsSelectorEventLoopPolicy,
+        ):
+            asyncio.set_event_loop_policy(
+                asyncio.WindowsSelectorEventLoopPolicy()
+            )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,8 +1,10 @@
 import asyncio
 import logging
 import re
+import warnings
 
 from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
 from inspect import isawaitable
 from os import environ
 from unittest.mock import Mock, patch
@@ -36,6 +38,32 @@ def test_app_loop_running(app: Sanic):
 
     request, response = app.test_client.get("/test")
     assert response.text == "pass"
+
+
+@pytest.mark.parametrize("has_loop", [True, False])
+def test_app_loop_without_running_loop(app: Sanic, has_loop: bool):
+    app.asgi = True
+
+    def check_loop():
+        loop = asyncio.new_event_loop() if has_loop else None
+        asyncio.set_event_loop(loop)
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("error", DeprecationWarning)
+                if has_loop:
+                    assert app.loop is loop
+                else:
+                    with pytest.raises(
+                        RuntimeError, match="no current event loop"
+                    ):
+                        app.loop
+        finally:
+            asyncio.set_event_loop(None)
+            if loop is not None:
+                loop.close()
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        executor.submit(check_loop).result()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Description

Fixes #3129

Python 3.14 deprecates `asyncio.get_event_loop_policy()` and `asyncio.set_event_loop_policy()` with `DeprecationWarning`. These APIs are still the recommended way to configure uvloop and Windows event loop policies, so the fix wraps calls in `warnings.catch_warnings()` on Python >= 3.14 to suppress warnings originating from the asyncio module.

### Changes
- `sanic/server/loop.py`: Wrapped event loop policy checks in `warnings.catch_warnings()` blocks for both `try_use_uvloop()` and `try_windows_loop()` functions

### Testing
On Python 3.14, running Sanic with uvloop should no longer emit:
```
DeprecationWarning: 'asyncio.get_event_loop_policy' is deprecated and slated for removal in Python 3.16
DeprecationWarning: 'asyncio.set_event_loop_policy' is deprecated and slated for removal in Python 3.16
```

The pattern is intentionally kept simple — once Python 3.16 provides a `loop_factory` API, the `warnings.catch_warnings` wrapper can be replaced with direct `set_event_loop_factory()` calls.