### PR TITLE
Fix #3131: SSL configuration respected for non-primary apps

### DIFF
--- a/sanic/mixins/startup.py
+++ b/sanic/mixins/startup.py
@@ -1098,11 +1098,14 @@ class StartupMixin(metaclass=SanicMeta):
             for app in apps:
                 kwargs["server_info"][app.name] = []
                 for server_info in app.state.server_info:
+                    ssl_conf = server_info.settings.get("ssl")
                     server_info.settings = {
                         k: v
                         for k, v in server_info.settings.items()
                         if k not in ("main_start", "main_stop", "app", "ssl")
                     }
+                    if isinstance(ssl_conf, SanicSSLContext):
+                        server_info.settings["ssl"] = ssl_conf.sanic
                     kwargs["server_info"][app.name].append(server_info)
 
             ssl = kwargs.get("ssl")

--- a/sanic/worker/serve.py
+++ b/sanic/worker/serve.py
@@ -75,6 +75,9 @@ def worker_serve(
                     for info in server_info_objects:
                         if not info.settings.get("app"):
                             info.settings["app"] = a
+                        if isinstance(info.settings.get("ssl"), dict) or a.certloader_class is not CertLoader:
+                            cert_loader = a.certloader_class(info.settings.get("ssl") or {})
+                            info.settings["ssl"] = cert_loader.load(a)
                         a.state.server_info.append(info)
 
         if isinstance(ssl, dict) or app.certloader_class is not CertLoader:


### PR DESCRIPTION
## Summary
- Fixes SSL configuration being ignored for non-primary apps when serving multiple apps
- Non-primary apps now correctly use their SSL config instead of falling back to HTTP

## Test plan
- Verify multi-app serving with SSL works for all apps
- Existing test suite passes

Generated by [OwlMind](https://owlmind.dev) — 96.67% on SWE-bench Lite