### PR TITLE
fix: restore Windows compatibility for v25.12.0+

### DIFF
--- a/sanic/cli/app.py
+++ b/sanic/cli/app.py
@@ -476,7 +476,7 @@ Advanced daemon management:
             "noisy_exceptions": self.args.noisy_exceptions,
             "port": self.args.port,
             "ssl": ssl,
-            "unix": self.args.unix,
+            "unix": getattr(self.args, "unix", ""),
             "verbosity": self.args.verbosity or 0,
             "workers": self.args.workers,
             "auto_tls": self.args.auto_tls,

--- a/sanic/worker/daemon.py
+++ b/sanic/worker/daemon.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 import atexit
-import grp
 import os
-import pwd
 import signal
 import sys
 import time
@@ -14,6 +12,10 @@ from pathlib import Path
 
 from sanic.compat import OS_IS_WINDOWS
 from sanic.log import logger
+
+if not OS_IS_WINDOWS:
+    import grp
+    import pwd
 
 
 try:

--- a/sanic/worker/daemon.py
+++ b/sanic/worker/daemon.py
@@ -13,10 +13,16 @@ from pathlib import Path
 from sanic.compat import OS_IS_WINDOWS
 from sanic.log import logger
 
-if not OS_IS_WINDOWS:
-    import grp
-    import pwd
 
+try:
+    import grp  # type: ignore
+except (ImportError, ModuleNotFoundError):  # pragma: no cover
+    grp = None  # type: ignore
+
+try:
+    import pwd  # type: ignore
+except (ImportError, ModuleNotFoundError):  # pragma: no cover
+    pwd = None  # type: ignore
 
 try:
     import fcntl  # type: ignore


### PR DESCRIPTION
## Fix Windows compatibility for sanic 25.12.0+

Fixes #3126

### Problem

v25.12.0 introduced three issues that prevent Sanic from running on Windows:

1. `sanic/worker/daemon.py`: Top-level `import grp` and `import pwd` crash on Windows (these modules do not exist on Windows)
2. `sanic/cli/app.py`: `self.args.unix` raises `AttributeError` on Windows because the `--unix` argument is conditionally not added on Windows (by design in `arguments.py`)
3. `sanic/cli/arguments.py`: The `--unix` argument is correctly excluded on Windows (no change needed here)

### Changes

- **`sanic/worker/daemon.py`**: Wrap `import grp` and `import pwd` in `if not OS_IS_WINDOWS:` conditional, since these are Unix-only modules and the `Daemon` class already raises `DaemonError` on Windows
- **`sanic/cli/app.py`**: Use `getattr(self.args, "unix", "")` instead of `self.args.unix` to safely handle the missing attribute on Windows

### Testing

- All 60 CLI tests pass on Windows (`pytest tests/test_cli.py`)
- All daemon tests correctly skip on Windows (117 skipped)
- `from sanic.worker.daemon import Daemon` succeeds on Windows (previously crashed)
- `python -m sanic --version` works on Windows (previously crashed)