### PR TITLE
Fix ASGI request creation exception responses

### DIFF
--- a/changelogs/2718.bugfix.rst
+++ b/changelogs/2718.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ASGI request creation exceptions to preserve their HTTP status codes.

--- a/sanic/asgi.py
+++ b/sanic/asgi.py
@@ -186,7 +186,7 @@ class ASGIApp:
                 raise
             if instance.exception is None:
                 instance.exception = e
-            instance.request = request_class(
+            instance.request = Request(
                 b"*",
                 Header(),
                 version,

--- a/sanic/asgi.py
+++ b/sanic/asgi.py
@@ -112,6 +112,7 @@ class ASGIApp:
     ws: WebSocketConnection | None
     stage: Stage
     response: BaseHTTPResponse | None
+    exception: Exception | None
 
     @classmethod
     async def create(
@@ -128,6 +129,7 @@ class ASGIApp:
         instance.transport.loop = sanic_app.loop
         instance.stage = Stage.IDLE
         instance.response = None
+        instance.exception = None
         instance.sanic_app.state.is_started = True
         setattr(instance.transport, "add_task", sanic_app.loop.create_task)
 
@@ -142,7 +144,10 @@ class ASGIApp:
                 ]
             )
         except UnicodeDecodeError:
-            raise BadRequest(
+            if scope["type"] != "http":
+                raise
+            headers = Header()
+            instance.exception = BadRequest(
                 "Header names can only contain US-ASCII characters"
             )
 
@@ -167,25 +172,45 @@ class ASGIApp:
             url_bytes = b"%b?%b" % (url_bytes, query)
 
         request_class = sanic_app.request_class or Request  # type: ignore
-        instance.request = request_class(
-            url_bytes,
-            headers,
-            version,
-            method,
-            instance.transport,
-            sanic_app,
-        )
+        try:
+            instance.request = request_class(
+                url_bytes,
+                headers,
+                version,
+                method,
+                instance.transport,
+                sanic_app,
+            )
+        except Exception as e:
+            if scope["type"] != "http":
+                raise
+            if instance.exception is None:
+                instance.exception = e
+            instance.request = request_class(
+                b"*",
+                Header(),
+                version,
+                method,
+                instance.transport,
+                sanic_app,
+            )
         request_class._current.set(instance.request)
         instance.request.stream = instance  # type: ignore
         instance.request_body = True
         instance.request.conn_info = ConnInfo(instance.transport)
 
-        await instance.sanic_app.dispatch(
-            "http.lifecycle.request",
-            inline=True,
-            context={"request": instance.request},
-            fail_not_found=False,
-        )
+        if instance.exception is None:
+            try:
+                await instance.sanic_app.dispatch(
+                    "http.lifecycle.request",
+                    inline=True,
+                    context={"request": instance.request},
+                    fail_not_found=False,
+                )
+            except Exception as e:
+                if scope["type"] != "http":
+                    raise
+                instance.exception = e
 
         return instance
 
@@ -255,6 +280,8 @@ class ASGIApp:
         """
         try:
             self.stage = Stage.HANDLER
+            if self.exception is not None:
+                raise self.exception
             await self.sanic_app.handle_request(self.request)
         except Exception as e:
             try:

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -13,7 +13,12 @@ from pytest import MonkeyPatch
 from sanic import Sanic
 from sanic.application.state import Mode
 from sanic.asgi import Lifespan, MockTransport
-from sanic.exceptions import BadRequest, Forbidden, ServiceUnavailable
+from sanic.exceptions import (
+    BadRequest,
+    Forbidden,
+    SanicException,
+    ServiceUnavailable,
+)
 from sanic.request import Request
 from sanic.response import json, text
 from sanic.server.websockets.connection import WebSocketConnection
@@ -655,11 +660,41 @@ async def test_asgi_headers_decoding(app: Sanic, monkeypatch: MonkeyPatch):
     monkeypatch.setattr(Headers, "__init__", mocked_headers_init)
 
     message = "Header names can only contain US-ASCII characters"
-    with pytest.raises(BadRequest, match=message):
-        _, response = await app.asgi_client.get("/", headers={"😂": "😅"})
+    _, response = await app.asgi_client.get("/", headers={"😂": "😅"})
+    assert response.status_code == 400
+    assert message in response.text
 
     _, response = await app.asgi_client.get("/", headers={"Test-Header": "😅"})
     assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_asgi_lifecycle_exception_status(app: Sanic):
+    @app.signal("http.lifecycle.request")
+    def raise_lifecycle_exception(request: Request):
+        raise SanicException("Short and stout", status_code=418)
+
+    _, response = await app.asgi_client.get("/")
+
+    assert response.status_code == 418
+    assert "Short and stout" in response.text
+
+
+@pytest.mark.asyncio
+async def test_asgi_request_creation_exception_status(app: Sanic):
+    class CreationErrorRequest(Request):
+        def __init__(self, url_bytes, *args, **kwargs):
+            if url_bytes != b"*":
+                raise SanicException(
+                    "Request creation failed", status_code=422
+                )
+            super().__init__(url_bytes, *args, **kwargs)
+
+    app.request_class = CreationErrorRequest
+    _, response = await app.asgi_client.get("/")
+
+    assert response.status_code == 422
+    assert "Request creation failed" in response.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -683,12 +683,8 @@ async def test_asgi_lifecycle_exception_status(app: Sanic):
 @pytest.mark.asyncio
 async def test_asgi_request_creation_exception_status(app: Sanic):
     class CreationErrorRequest(Request):
-        def __init__(self, url_bytes, *args, **kwargs):
-            if url_bytes != b"*":
-                raise SanicException(
-                    "Request creation failed", status_code=422
-                )
-            super().__init__(url_bytes, *args, **kwargs)
+        def __init__(self, *args, **kwargs):
+            raise SanicException("Request creation failed", status_code=422)
 
     app.request_class = CreationErrorRequest
     _, response = await app.asgi_client.get("/")


### PR DESCRIPTION
## Summary
- route HTTP exceptions raised during ASGI request setup through Sanic's normal exception handler
- preserve status codes from invalid headers, request construction, and `http.lifecycle.request` signals
- use an empty fallback request when construction itself fails, without reflecting malformed headers or paths
- leave WebSocket exception behavior unchanged

Fixes #2718.

## Tests
- `python -m pytest tests/test_asgi.py -q` (26 passed)
- `ruff check sanic/asgi.py tests/test_asgi.py`
- `ruff format sanic/asgi.py tests/test_asgi.py --check`
- `python setup.py check -r -s`

`mypy sanic/asgi.py` was also attempted locally, but the Windows run has existing unrelated failures for missing `types-ujson` stubs and Unix-only APIs such as `AF_UNIX`, `SIGKILL`, and `sched_getaffinity`.

The GitHub Actions type-checking job likewise currently fails in unchanged `sanic/pages/error.py` with mypy 2.3.0; the workflow's fail-fast behavior then cancels the remaining test matrix jobs. Lint and security jobs completed successfully.