### PR TITLE
docs: fix signal condition parameter

### DIFF
--- a/guide/content/en/guide/advanced/signals.md
+++ b/guide/content/en/guide/advanced/signals.md
@@ -58,10 +58,10 @@ async def handle_registration(request):
     app.add_signal(
         my_signal_handler,
         "something.happened.ohmy1",
-        conditions={"some_condition": "value"}
+        condition={"some_condition": "value"}
     )
 
-    @app.signal("something.happened.ohmy2", conditions={"some_condition": "value"})
+    @app.signal("something.happened.ohmy2", condition={"some_condition": "value"})
     async def my_signal_handler2():
         print("something happened")
     ```
@@ -343,4 +343,3 @@ Dispatching blueprint signals works similar in concept to [middleware](../basics
     assert app_counter == 1
     assert bp_counter == 2
     ```
-


### PR DESCRIPTION
Fixes #3176

## Summary

- Correct the signal registration examples to use the supported singular `condition` keyword.
- Keep the decorator and `add_signal` examples consistent with the public API.

## Testing

- `python -m pytest -q tests/test_signals.py` (49 passed)
- Rendered `guide/content/en/guide/advanced/signals.md` with the guide Markdown renderer
- `ruff check sanic/mixins/signals.py`
- `ruff format sanic/mixins/signals.py --check`
- `git diff --check`
