### PR TITLE
Fix secondary app signals in spawned workers

### DIFF
--- a/sanic/mixins/startup.py
+++ b/sanic/mixins/startup.py
@@ -1083,18 +1083,26 @@ class StartupMixin(metaclass=SanicMeta):
             kwargs["app_name"] = app.name
             kwargs["app_loader"] = app_loader
             kwargs["server_info"] = {}
-            kwargs["passthru"] = {
-                "auto_reload": app.auto_reload,
-                "state": {
-                    "verbosity": app.state.verbosity,
-                    "mode": app.state.mode,
-                },
-                "config": {
-                    "ACCESS_LOG": app.config.ACCESS_LOG,
-                    "NOISY_EXCEPTIONS": app.config.NOISY_EXCEPTIONS,
-                },
-                "shared_ctx": app.shared_ctx.__dict__,
+
+            def build_passthru(current: Sanic) -> dict[str, Any]:
+                return {
+                    "auto_reload": current.auto_reload,
+                    "state": {
+                        "verbosity": current.state.verbosity,
+                        "mode": current.state.mode,
+                    },
+                    "config": {
+                        "ACCESS_LOG": current.config.ACCESS_LOG,
+                        "NOISY_EXCEPTIONS": current.config.NOISY_EXCEPTIONS,
+                    },
+                    "shared_ctx": current.shared_ctx.__dict__,
+                }
+
+            app_passthru = {
+                current.name: build_passthru(current) for current in apps
             }
+            kwargs["passthru"] = build_passthru(app)
+            kwargs["app_passthru"] = app_passthru
             for app in apps:
                 kwargs["server_info"][app.name] = []
                 for server_info in app.state.server_info:

--- a/sanic/worker/serve.py
+++ b/sanic/worker/serve.py
@@ -48,6 +48,7 @@ def worker_serve(
     version=HTTP.VERSION_1,
     config: bytes | str | dict[str, Any] | Any | None = None,
     passthru: dict[str, Any] | None = None,
+    app_passthru: dict[str, dict[str, Any]] | None = None,
 ):
     try:
         from sanic import Sanic
@@ -99,6 +100,9 @@ def worker_serve(
 
             # Run secondary servers
             apps = list(Sanic._app_registry.values())
+            for secondary in apps:
+                if secondary is not app:
+                    secondary.refresh((app_passthru or {}).get(secondary.name))
             app.before_server_start(partial(app._start_servers, apps=apps))
             for a in apps:
                 a.multiplexer = WorkerMultiplexer(

--- a/tests/worker/test_worker_serve.py
+++ b/tests/worker/test_worker_serve.py
@@ -118,7 +118,8 @@ def test_serve_passes_secondary_app_state(worker_manager: Mock, app: Sanic):
     app.prepare(dev=True)
     secondary.prepare(dev=True)
 
-    Sanic.serve(primary=app)
+    with patch("sanic.mixins.startup.configure_socket"):
+        Sanic.serve(primary=app)
 
     worker_kwargs = worker_manager.call_args.args[2]
     secondary_passthru = worker_kwargs["app_passthru"][secondary.name]

--- a/tests/worker/test_worker_serve.py
+++ b/tests/worker/test_worker_serve.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 from os import environ
@@ -6,6 +7,8 @@ from unittest.mock import Mock, patch
 import pytest
 
 from sanic.app import Sanic
+from sanic.application.constants import Mode
+from sanic.signals import Event
 from sanic.worker.loader import AppLoader
 from sanic.worker.multiplexer import WorkerMultiplexer
 from sanic.worker.process import Worker, WorkerProcess
@@ -73,6 +76,54 @@ def test_has_multiplexer(app: Sanic):
     assert isinstance(app.multiplexer, WorkerMultiplexer)
 
     del environ["SANIC_WORKER_NAME"]
+
+
+def test_secondary_app_receives_worker_passthru(app: Sanic):
+    secondary = Sanic("secondary")
+    app_passthru = {
+        secondary.name: {
+            "state": {"mode": Mode.DEBUG},
+        }
+    }
+    environ["SANIC_WORKER_NAME"] = (
+        f"{Worker.WORKER_PREFIX}-{WorkerProcess.SERVER_LABEL}-FOO"
+    )
+
+    try:
+        with patch("sanic.worker.serve._serve_http_1"):
+            worker_serve(
+                **args(
+                    app,
+                    monitor_publisher=Mock(),
+                    worker_state=Mock(),
+                    app_passthru=app_passthru,
+                )
+            )
+
+        async def startup_and_dispatch():
+            await secondary._startup()
+            await secondary.dispatch(Event.HTTP_LIFECYCLE_BEGIN, inline=True)
+
+        asyncio.run(startup_and_dispatch())
+    finally:
+        del environ["SANIC_WORKER_NAME"]
+
+    assert secondary.state.is_debug
+    assert secondary.config.TOUCHUP is False
+
+
+@patch("sanic.mixins.startup.WorkerManager")
+def test_serve_passes_secondary_app_state(worker_manager: Mock, app: Sanic):
+    secondary = Sanic("secondary")
+    app.prepare(dev=True)
+    secondary.prepare(dev=True)
+
+    Sanic.serve(primary=app)
+
+    worker_kwargs = worker_manager.call_args.args[2]
+    secondary_passthru = worker_kwargs["app_passthru"][secondary.name]
+    assert secondary_passthru["state"]["mode"] is Mode.DEBUG
+    assert secondary_passthru["config"]["ACCESS_LOG"] is True
 
 
 @patch("sanic.mixins.startup.WorkerManager")


### PR DESCRIPTION
## Summary

- preserve each registered app's runtime state when configuring spawned workers
- refresh secondary apps before their servers start
- verify dev-mode built-in HTTP signals remain available on secondary apps

## Why

In spawn mode, the primary app received its prepared state through `passthru`, but secondary apps were re-imported without their per-app mode and config. A secondary app prepared with `dev=True` could therefore start with production touchups enabled and fail to resolve built-in HTTP lifecycle signals.

## Validation

- `python -m pytest tests/worker/test_worker_serve.py tests/worker/test_startup.py -q` — 19 passed, 1 skipped
- `python -m ruff check sanic/mixins/startup.py sanic/worker/serve.py tests/worker/test_worker_serve.py`
- `python -m ruff format --check sanic/mixins/startup.py sanic/worker/serve.py tests/worker/test_worker_serve.py`
- `git diff --check`

Fixes #3179
