### PR TITLE
Incorrect Parameter name in Signals Documentation

### DIFF
--- a/docs/sanic/releases/22/22.12.md
+++ b/docs/sanic/releases/22/22.12.md
@@ -42,7 +42,7 @@ _Current version_
 
 ### Deprecations and Removals
 
-- [#2608](https://github.com/sanic-org/sanic/pull/2608) [#2630](https://github.com/sanic-org/sanic/pull/2630) Signal conditions and triggers saved on `signal.extra` 
+- [#2608](https://github.com/sanic-org/sanic/pull/2608) [#2630](https://github.com/sanic-org/sanic/pull/2630) Signal condition and triggers saved on `signal.extra` 
 - [#2626](https://github.com/sanic-org/sanic/pull/2626) Move to HTTP Inspector
     - 🚨 *BREAKING CHANGE*: Moves the Inspector to a Sanic app from a simple TCP socket with a custom protocol
     - *DEPRECATE*: The `--inspect*` commands have been deprecated in favor of `inspect ...` commands


### PR DESCRIPTION
Fixes #3176

This corrects `conditions` to `condition` in `docs/sanic/releases/22/22.12.md`, as reported in #3176.

The change is intentionally minimal and only touches the exact phrase reported in the issue.

Fixes #3176