### PR TITLE
Fix Windows socket address reuse

### DIFF
--- a/changelogs/2660.bugfix.rst
+++ b/changelogs/2660.bugfix.rst
@@ -1,0 +1,1 @@
+Do not set ``SO_REUSEADDR`` on Windows listener sockets, preventing multiple servers from binding to the same address and port.

--- a/sanic/server/socket.py
+++ b/sanic/server/socket.py
@@ -8,6 +8,7 @@ from ipaddress import ip_address
 from pathlib import Path
 from typing import Any
 
+from sanic.compat import OS_IS_WINDOWS
 from sanic.http.constants import HTTP
 
 
@@ -28,7 +29,8 @@ def bind_socket(host: str, port: int, *, backlog=100) -> socket.socket:
         )
     except ValueError:  # Hostname, may become AF_INET or AF_INET6
         sock = socket.socket()
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    if not OS_IS_WINDOWS:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     sock.bind(location)
     sock.listen(backlog)
     sock.set_inheritable(True)

--- a/tests/worker/test_socket.py
+++ b/tests/worker/test_socket.py
@@ -1,10 +1,24 @@
 from pathlib import Path
+from unittest.mock import Mock, patch
 
 from sanic.server.socket import (
+    bind_socket,
     bind_unix_socket,
     configure_socket,
     remove_unix_socket,
 )
+
+
+def test_bind_socket_does_not_reuse_address_on_windows():
+    sock = Mock()
+    with (
+        patch("sanic.server.socket.OS_IS_WINDOWS", True),
+        patch("sanic.server.socket.socket.socket", return_value=sock),
+    ):
+        bind_socket("127.0.0.1", 8000)
+
+    sock.setsockopt.assert_not_called()
+    sock.bind.assert_called_once_with(("127.0.0.1", 8000))
 
 
 def test_setup_and_teardown_unix():

--- a/tests/worker/test_socket.py
+++ b/tests/worker/test_socket.py
@@ -12,7 +12,7 @@ from sanic.server.socket import (
 def test_bind_socket_does_not_reuse_address_on_windows():
     sock = Mock()
     with (
-        patch("sanic.server.socket.OS_IS_WINDOWS", True),
+        patch("sanic.server.socket.OS_IS_WINDOWS", True, create=True),
         patch("sanic.server.socket.socket.socket", return_value=sock),
     ):
         bind_socket("127.0.0.1", 8000)


### PR DESCRIPTION
## Summary

- avoid setting `SO_REUSEADDR` when binding TCP server sockets on Windows
- preserve the existing socket option behavior on other platforms
- add a regression test for the Windows branch

On Windows, `SO_REUSEADDR` allows another socket using the same option to bind the exact same address and port. The second server can therefore appear to start successfully while requests continue reaching the first server.

Fixes #2660.

## Validation

- `python -m pytest tests/worker/test_socket.py::test_bind_socket_does_not_reuse_address_on_windows -q` — 1 passed
- `python -m ruff check sanic/server/socket.py tests/worker/test_socket.py` — passed
- `python -m ruff format --check sanic/server/socket.py tests/worker/test_socket.py` — passed
- Windows runtime check: before the change, a second socket using `SO_REUSEADDR` could bind the same `127.0.0.1` port; after the change, the second `bind_socket` call fails with WinError 10048

Running the complete `tests/worker/test_socket.py` file on Windows also executes two pre-existing Unix socket tests. Those fail because this Python build does not expose `socket.AF_UNIX`; the new targeted regression test passes.