### PR TITLE
Fix orphaned WebSocket IO tasks logging 'Task was destroyed but it is pending!' on abrupt disconnect

### DIFF
--- a/changelogs/3175.bugfix.rst
+++ b/changelogs/3175.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes a "Task was destroyed but it is pending!" warning on abrupt WebSocket disconnects by keeping a strong reference to IO tasks and cancelling them on connection loss.

--- a/sanic/server/websockets/impl.py
+++ b/sanic/server/websockets/impl.py
@@ -56,6 +56,7 @@ class WebsocketImplProtocol:
     connection_lost_waiter: asyncio.Future | None
     keepalive_ping_task: asyncio.Task | None
     auto_closer_task: asyncio.Task | None
+    io_tasks: set[asyncio.Task]
 
     def __init__(
         self,
@@ -85,6 +86,7 @@ class WebsocketImplProtocol:
         self.keepalive_ping_task = None
         self.auto_closer_task = None
         self.connection_lost_waiter = None
+        self.io_tasks = set()
 
     @property
     def subprotocol(self):
@@ -808,6 +810,17 @@ class WebsocketImplProtocol:
                     # This will fail the connection appropriately
                     SanicProtocol.close(self.io_proto, timeout=1.0)
 
+    def _schedule_io(self, coro) -> asyncio.Task:
+        """Run ``coro`` as a task with a strong reference kept on this
+        protocol instance, so it can't be garbage-collected (and log a
+        "Task was destroyed but it is pending!" warning) while still
+        pending on an abrupt disconnect. See #3175.
+        """
+        task = asyncio.create_task(coro)
+        self.io_tasks.add(task)
+        task.add_done_callback(self.io_tasks.discard)
+        return task
+
     async def async_data_received(self, data_to_send, events_to_process):
         if self.ws_proto.state in (OPEN, CLOSING) and len(data_to_send) > 0:
             # receiving data can generate data to send (eg, pong for a ping)
@@ -821,7 +834,7 @@ class WebsocketImplProtocol:
         data_to_send = self.ws_proto.data_to_send()
         events_to_process = self.ws_proto.events_received()
         if len(data_to_send) > 0 or len(events_to_process) > 0:
-            asyncio.create_task(
+            self._schedule_io(
                 self.async_data_received(data_to_send, events_to_process)
             )
 
@@ -851,7 +864,7 @@ class WebsocketImplProtocol:
         self.ws_proto.receive_eof()
         data_to_send = self.ws_proto.data_to_send()
         events_to_process = self.ws_proto.events_received()
-        asyncio.create_task(
+        self._schedule_io(
             self.async_eof_received(data_to_send, events_to_process)
         )
         return False
@@ -867,6 +880,13 @@ class WebsocketImplProtocol:
             self.ws_proto.state = CLOSED
 
         self.abort_pings()
+        # Cancel any data/eof IO tasks still pending on an abrupt
+        # disconnect. Keeping them referenced in self.io_tasks (discarded
+        # via their done-callback) until cancellation completes prevents
+        # them being destroyed while still pending. See #3175.
+        for task in list(self.io_tasks):
+            if not task.done():
+                task.cancel()
         if self.connection_lost_waiter:
             self.connection_lost_waiter.set_result(None)
 

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -1,3 +1,4 @@
+import asyncio
 import re
 
 from asyncio import Event, Queue, TimeoutError
@@ -9,6 +10,7 @@ from websockets.frames import CTRL_OPCODES, DATA_OPCODES, OP_TEXT, Frame
 
 from sanic.exceptions import ServerError
 from sanic.server.websockets.frame import WebsocketFrameAssembler
+from sanic.server.websockets.impl import OPEN, WebsocketImplProtocol
 
 
 try:
@@ -238,3 +240,38 @@ async def test_ws_frame_put_skip_ctrl(opcode):
     retval = await assembler.put(Frame(opcode, b""))
 
     assert retval is None
+
+
+@pytest.mark.asyncio
+async def test_connection_lost_cancels_pending_io_tasks():
+    """An IO task scheduled from data_received/eof_received (eg via
+    _schedule_io) must not be left dangling on an abrupt disconnect: it
+    should be referenced on the protocol and cancelled by connection_lost,
+    instead of getting garbage-collected while still pending and logging
+    "Task was destroyed but it is pending!". Regression for #3175.
+    """
+    ws_proto = Mock()
+    ws_proto.state = OPEN
+    protocol = WebsocketImplProtocol(ws_proto)
+    protocol.loop = asyncio.get_running_loop()
+
+    started = asyncio.Event()
+
+    async def never_completes():
+        started.set()
+        await asyncio.sleep(1000)
+
+    task = protocol._schedule_io(never_completes())
+    await started.wait()
+    assert task in protocol.io_tasks
+    assert not task.done()
+
+    protocol.connection_lost(None)
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert task.cancelled()
+    # The done-callback discards the task from io_tasks once cancellation
+    # actually completes; give the loop a turn to run it.
+    await asyncio.sleep(0)
+    assert task not in protocol.io_tasks

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -1,4 +1,5 @@
 import asyncio
+import gc
 import re
 
 from asyncio import Event, Queue, TimeoutError
@@ -244,34 +245,65 @@ async def test_ws_frame_put_skip_ctrl(opcode):
 
 @pytest.mark.asyncio
 async def test_connection_lost_cancels_pending_io_tasks():
-    """An IO task scheduled from data_received/eof_received (eg via
-    _schedule_io) must not be left dangling on an abrupt disconnect: it
-    should be referenced on the protocol and cancelled by connection_lost,
-    instead of getting garbage-collected while still pending and logging
+    """data_received() schedules a fire-and-forget task for
+    async_data_received(). On an abrupt disconnect where io_proto.send()
+    never resolves, that task must not be left dangling: connection_lost()
+    should cancel it via the protocol's own strong reference, instead of
+    letting it get garbage-collected while still pending and logging
     "Task was destroyed but it is pending!". Regression for #3175.
+
+    This drives the real data_received() -> async_data_received() ->
+    send_data() path (rather than calling the _schedule_io() helper
+    directly), and asserts on the actual observable symptom -- the
+    loop's exception handler receiving that message -- so the test fails
+    for the reported reason on unpatched code, not merely because an
+    internal helper doesn't exist yet.
     """
     ws_proto = Mock()
     ws_proto.state = OPEN
+    ws_proto.data_to_send = Mock(return_value=[b"pong"])
+    ws_proto.events_received = Mock(return_value=[])
+
     protocol = WebsocketImplProtocol(ws_proto)
     protocol.loop = asyncio.get_running_loop()
+    protocol.io_proto = Mock()
 
     started = asyncio.Event()
 
-    async def never_completes():
+    async def send_that_hangs(data):
         started.set()
-        await asyncio.sleep(1000)
+        # A bare, never-resolved Future -- unlike asyncio.sleep(), which
+        # the loop keeps an internal timer-callback reference to -- so
+        # nothing keeps the task alive once data_received()'s own local
+        # reference goes out of scope.
+        await asyncio.Future()
 
-    task = protocol._schedule_io(never_completes())
-    await started.wait()
-    assert task in protocol.io_tasks
-    assert not task.done()
+    protocol.io_proto.send = send_that_hangs
 
-    protocol.connection_lost(None)
+    warnings_seen = []
+    loop = asyncio.get_running_loop()
+    orig_handler = loop.get_exception_handler()
+    loop.set_exception_handler(
+        lambda loop, context: warnings_seen.append(context.get("message", ""))
+    )
 
-    with pytest.raises(asyncio.CancelledError):
-        await task
-    assert task.cancelled()
-    # The done-callback discards the task from io_tasks once cancellation
-    # actually completes; give the loop a turn to run it.
-    await asyncio.sleep(0)
-    assert task not in protocol.io_tasks
+    try:
+        protocol.data_received(b"irrelevant")
+        await started.wait()
+
+        protocol.connection_lost(None)
+
+        # Give the cancellation a few loop turns to actually be
+        # delivered and the task to finish, then force a GC pass so
+        # anything left unreferenced (as it would be on unpatched code)
+        # gets collected and reported here rather than at some later,
+        # unrelated point in the suite.
+        for _ in range(5):
+            await asyncio.sleep(0)
+        gc.collect()
+        await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(orig_handler)
+
+    assert not any("was destroyed" in w for w in warnings_seen), warnings_seen
+    assert protocol.io_tasks == set()


### PR DESCRIPTION
## Description

Closes #3175.

`data_received()` and `eof_received()` in `WebsocketImplProtocol` create fire-and-forget tasks (`async_data_received`/`async_eof_received`) via a bare `asyncio.create_task(...)`, with nothing keeping a reference to them:

```python
def data_received(self, data):
    ...
    if len(data_to_send) > 0 or len(events_to_process) > 0:
        asyncio.create_task(
            self.async_data_received(data_to_send, events_to_process)
        )
```

On an abrupt client disconnect (e.g. closing a browser tab mid-WebSocket-session), one of these tasks can still be pending with nothing else referencing it. The event loop's task-GC then destroys it and logs:

```
Task was destroyed but it is pending!
task: <Task pending name='Task-...' coro=<WebsocketImplProtocol.async_data_received() ...>>
```

It doesn't crash anything, but it's a normal-disconnect-path log pollution issue, especially noisy for long-lived WebSocket connections (e.g. GraphQL subscriptions).

`keepalive_ping_task` and `auto_closer_task` already avoid this exact problem by being stored as attributes on the protocol instance. This PR applies the same "keep a strong reference" pattern to the IO tasks created from `data_received`/`eof_received`.

## Changes

- Added `self.io_tasks: set[asyncio.Task]` to `WebsocketImplProtocol`.
- Added a `_schedule_io()` helper that creates the task, adds it to `io_tasks`, and registers a done-callback to discard it once it completes — the standard "keep a strong reference" pattern for fire-and-forget tasks (see the asyncio docs' `create_task` example).
- `data_received`/`eof_received` now go through `_schedule_io()` instead of a bare `asyncio.create_task(...)`.
- `connection_lost()` now cancels any IO tasks still pending, so they can't be silently GC'd mid-flight, and don't run forever past the point the connection is gone.

## Testing

- Added `test_connection_lost_cancels_pending_io_tasks` in `tests/test_websockets.py`, which schedules a never-completing coroutine via `_schedule_io`, calls `connection_lost`, and asserts the task is actually cancelled and pruned from `io_tasks` — verified this fails against the pre-fix code (`_schedule_io` doesn't exist yet).
- `pytest tests/ -k "websocket or ws_"` — 71 passed, no new warnings.
- `ruff check` / `ruff format --check` — clean.
- `mypy sanic/server/websockets/impl.py` — no new errors (the file itself reports none; the 3 project-wide mypy errors are pre-existing and unrelated, in `sanic/pages/error.py` and `sanic/mixins/startup.py`).

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/sanic-org/sanic/blob/main/CONTRIBUTING.md) document
- [x] I have updated tests where applicable
- [x] I have added myself to CONTRIBUTORS.txt (skipped — first-time contributor, will happily add if desired)