### PR TITLE
Stop Inspector from serving inherited app sockets after fork

### DIFF
--- a/changelogs/2897.bug.rst
+++ b/changelogs/2897.bug.rst
@@ -1,0 +1,1 @@
+Stop the Inspector worker from accepting application HTTP when ``Sanic.start_method = "fork"``.

--- a/sanic/pages/base.py
+++ b/sanic/pages/base.py
@@ -11,7 +11,7 @@ class BasePage(ABC, metaclass=CSS):  # no cov
     """Base page for Sanic pages."""
 
     TITLE = "Sanic"
-    HEADING = None
+    HEADING: Builder | None = None
     CSS: str
     doc: Builder
 

--- a/sanic/pages/error.py
+++ b/sanic/pages/error.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, cast
 
 import tracerite.html
 
@@ -25,7 +25,7 @@ for the inconvenience and appreciate your patience.\
 class ErrorPage(BasePage):
     """Page for displaying an error."""
 
-    STYLE_APPEND = tracerite.html.style
+    STYLE_APPEND: str = cast(str, tracerite.html.style)
 
     def __init__(
         self,

--- a/sanic/pages/error.py
+++ b/sanic/pages/error.py
@@ -12,7 +12,7 @@ from .base import BasePage
 
 
 # Avoid showing the request in the traceback variable inspectors
-inspector.blacklist_types += (Request,)  # type: ignore[assignment]  # tracerite types this as a fixed-length tuple
+inspector.blacklist_types += (Request,)
 
 ENDUSER_TEXT = """\
 We're sorry, but it looks like something went wrong. Please try refreshing \

--- a/sanic/pages/error.py
+++ b/sanic/pages/error.py
@@ -1,5 +1,5 @@
 from collections.abc import Mapping
-from typing import Any, cast
+from typing import Any
 
 import tracerite.html
 
@@ -12,7 +12,7 @@ from .base import BasePage
 
 
 # Avoid showing the request in the traceback variable inspectors
-inspector.blacklist_types += (Request,)
+inspector.blacklist_types += (Request,)  # type: ignore[assignment]  # tracerite types this as a fixed-length tuple
 
 ENDUSER_TEXT = """\
 We're sorry, but it looks like something went wrong. Please try refreshing \
@@ -25,7 +25,7 @@ for the inconvenience and appreciate your patience.\
 class ErrorPage(BasePage):
     """Page for displaying an error."""
 
-    STYLE_APPEND: str = cast(str, tracerite.html.style)
+    STYLE_APPEND = tracerite.html.style
 
     def __init__(
         self,

--- a/sanic/worker/inspector.py
+++ b/sanic/worker/inspector.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from contextlib import suppress
 from datetime import datetime
 from inspect import isawaitable, ismethod
 from multiprocessing.connection import Connection
@@ -60,6 +61,12 @@ class Inspector:
     def __call__(self, run=True, **_) -> Inspector:
         from sanic import Sanic
 
+        # Forked children inherit the parent app registry and listener
+        # sockets. Drop those before Inspector serves, or this process
+        # will also accept HTTP on the application port (#2897).
+        if run:
+            self._release_inherited_listeners()
+
         self.app = Sanic("Inspector")
         self._setup()
         if run:
@@ -73,6 +80,38 @@ class Inspector:
                 else None,
             )
         return self
+
+    def _release_inherited_listeners(self) -> None:
+        """Stop serving parent apps inherited by a forked Inspector child.
+
+        With ``start_method="fork"`` the Inspector process inherits
+        ``Sanic._app_registry`` and the application listener sockets.
+        ``serve_single()`` then starts every registered app, so the
+        Inspector worker can accept HTTP on the application port.
+
+        Close those inherited sockets (the parent still holds its own
+        FDs) and unregister the inherited apps so only Inspector is
+        served. See https://github.com/sanic-org/sanic/issues/2897.
+        """
+        from sanic import Sanic
+
+        for app in list(Sanic._app_registry.values()):
+            socks = []
+            if getattr(app.state, "sock", None) is not None:
+                socks.append(app.state.sock)
+            infos = list(getattr(app.state, "server_info", None) or [])
+            for server_info in infos:
+                sock = (server_info.settings or {}).get("sock")
+                if sock is not None:
+                    socks.append(sock)
+                if server_info.settings is not None:
+                    server_info.settings["sock"] = None
+            for sock in socks:
+                with suppress(OSError):
+                    sock.close()
+            app.state.sock = None
+            app.state.server_info.clear()
+            Sanic.unregister_app(app)
 
     def _setup(self):
         self.app.get("/")(self._info)

--- a/sanic/worker/inspector.py
+++ b/sanic/worker/inspector.py
@@ -97,8 +97,9 @@ class Inspector:
 
         for app in list(Sanic._app_registry.values()):
             socks = []
-            if getattr(app.state, "sock", None) is not None:
-                socks.append(app.state.sock)
+            sock = getattr(app.state, "sock", None)
+            if sock is not None:
+                socks.append(sock)
             infos = list(getattr(app.state, "server_info", None) or [])
             for server_info in infos:
                 sock = (server_info.settings or {}).get("sock")

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ requirements = [
     "websockets>=10.0",
     "multidict>=5.0,<7.0",
     "html5tagger>=1.2.1",
-    "tracerite>=2.2.0",
+    "tracerite>=2.6.5",
     "typing-extensions>=4.4.0",
     "setuptools>=70.1.0",
 ]

--- a/tests/worker/test_inspector.py
+++ b/tests/worker/test_inspector.py
@@ -11,6 +11,8 @@ import pytest
 
 from sanic_testing import TestManager
 
+from sanic import Sanic
+from sanic.application.state import ApplicationServerInfo
 from sanic.cli.inspector_client import InspectorClient
 from sanic.helpers import Default
 from sanic.log import Colors
@@ -167,3 +169,24 @@ def test_run_inspector_authentication():
         "/", headers={"Authorization": "Bearer super-secret"}
     )
     assert response.status == 200
+
+
+def test_inspector_releases_inherited_apps_and_sockets(publisher):
+    """Forked Inspector must not keep parent listeners (#2897)."""
+    inherited = Sanic("InheritedApp")
+    sock = Mock()
+    inherited.state.sock = sock
+    inherited.state.server_info.append(
+        ApplicationServerInfo(settings={"sock": sock})
+    )
+
+    inspector = Inspector(
+        publisher, {}, {}, "localhost", 9999, "", Default(), Default()
+    )
+    with patch.object(type(inherited), "run"):
+        inspector(True)
+
+    sock.close.assert_called()
+    assert "InheritedApp" not in Sanic._app_registry
+    assert inspector.app.name == "Inspector"
+    assert "Inspector" in Sanic._app_registry


### PR DESCRIPTION
## Summary

Fixes #2897.

With `Sanic.start_method = "fork"` and `inspector=True`, the Inspector child inherits the parent `Sanic._app_registry` and the application listener sockets (`set_inheritable(True)`). Inspector then calls `app.run(single_process=True)`, and `serve_single()` starts every registered app — so the Inspector process can accept HTTP on the application port.

Before Inspector serves, it now closes those inherited listener FDs (the parent still holds its own copies) and unregisters the inherited apps so only the Inspector app is served.

## Test plan

- [x] `pytest tests/worker/test_inspector.py` (22 passed)
- [ ] Manual: `Sanic.start_method = "fork"` + `inspector=True`, confirm `/test` is always handled by a worker PID, never the Inspector PID