### PR TITLE
fix: pass status code from exceptions in ASGI mode (#2718)

### DIFF
--- a/sanic/asgi.py
+++ b/sanic/asgi.py
@@ -260,4 +260,20 @@ class ASGIApp:
             try:
                 await self.sanic_app.handle_exception(self.request, e)
             except Exception as exc:
-                await self.sanic_app.handle_exception(self.request, exc, False)
+                # If the exception has a status_code attribute (SanicException),
+                # use it; otherwise default to 500
+                status_code = getattr(exc, "status_code", 500)
+                await self.transport.send(
+                    {
+                        "type": "http.response.start",
+                        "status": status_code,
+                        "headers": [],
+                    }
+                )
+                await self.transport.send(
+                    {
+                        "type": "http.response.body",
+                        "body": str(exc).encode(),
+                        "more_body": False,
+                    }
+                )


### PR DESCRIPTION
## Problem

When an exception is raised in the ASGI lifecycle (but not in a handler), the status code from the exception was not being passed to the ASGI server. This caused all exceptions to return 500 instead of their actual status code.

For example, raising a BadRequest exception in asgi.py would cause the ASGI server to return 500, instead of the expected 400.

## Solution

This fix extracts the status_code attribute from SanicException and sends it in the http.response.start message, allowing the ASGI server to return the correct HTTP status code.

## Changes

Modified :
- Added status code extraction from exceptions in the error handling path
- Sends proper http.response.start and http.response.body messages with the correct status code

## Testing

The fix can be tested by raising a SanicException (like BadRequest) in the ASGI lifecycle and verifying that the correct status code is returned.

Closes #2718