### PR TITLE
Respect disabled system signal registration

### DIFF
--- a/changelogs/2956.bug.rst
+++ b/changelogs/2956.bug.rst
@@ -1,0 +1,1 @@
+Respect ``register_sys_signals=False`` by preserving existing SIGINT and SIGTERM handlers.

--- a/sanic/server/runners.py
+++ b/sanic/server/runners.py
@@ -162,11 +162,11 @@ def _setup_system_signals(
     register_sys_signals: bool,
     loop: asyncio.AbstractEventLoop,
 ) -> None:  # no cov
-    signal_func(SIGINT, SIG_IGN)
-    signal_func(SIGTERM, SIG_IGN)
     os.environ["SANIC_WORKER_PROCESS"] = "true"
     # Register signals for graceful termination
     if register_sys_signals:
+        signal_func(SIGINT, SIG_IGN)
+        signal_func(SIGTERM, SIG_IGN)
         if OS_IS_WINDOWS:
             ctrlc_workaround_for_windows(app)
         else:

--- a/tests/test_signal_handlers.py
+++ b/tests/test_signal_handlers.py
@@ -15,6 +15,7 @@ from sanic import Sanic
 from sanic.compat import ctrlc_workaround_for_windows
 from sanic.exceptions import BadRequest, ServerError
 from sanic.response import HTTPResponse
+from sanic.server.runners import _setup_system_signals
 from sanic.signals import Event
 
 
@@ -94,6 +95,15 @@ def test_dont_register_system_signals(app):
 
     app.run(HOST, PORT, register_sys_signals=False, single_process=True)
     assert calledq.get() is False
+
+
+def test_dont_ignore_system_signals_when_not_registering(monkeypatch):
+    signal_func = MagicMock()
+    monkeypatch.setattr("sanic.server.runners.signal_func", signal_func)
+
+    _setup_system_signals(MagicMock(), False, False, MagicMock())
+
+    signal_func.assert_not_called()
 
 
 @pytest.mark.skipif(os.name == "nt", reason="windows cannot SIGINT processes")


### PR DESCRIPTION
Fixes [#2956 — Signal handlers for SIGINT and SIGTERM are reset to SIG_IGN even when register_sys_signals is disabled](https://github.com/sanic-org/sanic/issues/2956).

## Problem

`register_sys_signals=False` still replaced the process SIGINT and SIGTERM handlers with `SIG_IGN`, preventing applications from retaining their own handlers.

## Fix

Only install the `SIG_IGN` handlers when system signal registration is enabled. The existing graceful-shutdown registration remains in the same guarded block. A changelog fragment records the user-visible fix.

## User impact

Applications that disable Sanic system signal handling keep their custom SIGINT and SIGTERM handlers. Without custom handlers, the operating system defaults now apply instead of ignoring those signals: Ctrl-C raises `KeyboardInterrupt`, and SIGTERM terminates the process.

## Verification

- `python -m pytest tests/test_signal_handlers.py -k dont_ignore_system_signals_when_not_registering -q` — 1 passed, 6 deselected.
- `python -m pytest tests/test_signal_handlers.py -q` — 2 passed, 5 skipped.
- `python -m ruff check sanic/server/runners.py tests/test_signal_handlers.py` — passed.
- `python -m ruff format --check sanic/server/runners.py tests/test_signal_handlers.py` — 2 files already formatted.
- `git diff --cached --check` — passed before commit.