### PR TITLE
Fix test client Address already in use on sequential requests

### DIFF
--- a/sanic/mixins/startup.py
+++ b/sanic/mixins/startup.py
@@ -25,7 +25,7 @@ from multiprocessing import (
 )
 from multiprocessing.context import BaseContext
 from pathlib import Path
-from socket import SHUT_RDWR, socket
+from socket import socket
 from ssl import SSLContext
 from time import sleep
 from typing import (
@@ -60,7 +60,11 @@ from sanic.server.loop import try_windows_loop
 from sanic.server.protocols.http_protocol import HttpProtocol
 from sanic.server.protocols.websocket_protocol import WebSocketProtocol
 from sanic.server.runners import serve
-from sanic.server.socket import configure_socket, remove_unix_socket
+from sanic.server.socket import (
+    close_socket,
+    configure_socket,
+    remove_unix_socket,
+)
 from sanic.worker.loader import AppLoader
 from sanic.worker.manager import WorkerManager
 from sanic.worker.multiplexer import WorkerMultiplexer
@@ -1172,11 +1176,7 @@ class StartupMixin(metaclass=SanicMeta):
                 app.signal_router.reset()
 
             for sock in socks:
-                try:
-                    sock.shutdown(SHUT_RDWR)
-                except OSError:
-                    ...
-                sock.close()
+                close_socket(sock)
             socks = []
 
             trigger_events(main_stop, loop, primary)
@@ -1309,8 +1309,7 @@ class StartupMixin(metaclass=SanicMeta):
                 app.router.reset()
                 app.signal_router.reset()
 
-            if sock:
-                sock.close()
+            close_socket(sock)
 
             cls._cleanup_env_vars()
             cls._cleanup_apps()

--- a/sanic/pages/base.py
+++ b/sanic/pages/base.py
@@ -11,7 +11,7 @@ class BasePage(ABC, metaclass=CSS):  # no cov
     """Base page for Sanic pages."""
 
     TITLE = "Sanic"
-    HEADING = None
+    HEADING: str | Builder | None = None
     CSS: str
     doc: Builder
 

--- a/sanic/server/runners.py
+++ b/sanic/server/runners.py
@@ -28,7 +28,11 @@ from sanic.logging.setup import setup_logging
 from sanic.models.server_types import Signal
 from sanic.server.async_server import AsyncioServer
 from sanic.server.protocols.http_protocol import Http3Protocol, HttpProtocol
-from sanic.server.socket import bind_unix_socket, remove_unix_socket
+from sanic.server.socket import (
+    bind_unix_socket,
+    close_socket,
+    remove_unix_socket,
+)
 
 
 try:
@@ -220,7 +224,11 @@ def _run_server_forever(loop, before_stop, after_stop, cleanup, unix, pid):
         _run_shutdown_coro(loop, before_stop)
 
         if cleanup:
-            cleanup()
+            try:
+                cleanup()
+            except (RuntimeError, KeyboardInterrupt):
+                # Same uvloop/asyncio-after-stop() cases as _run_shutdown_coro
+                pass
 
         _run_shutdown_coro(loop, after_stop)
 
@@ -303,9 +311,14 @@ def _serve_http_1(
         return
 
     def _cleanup():
-        # Wait for event loop to finish and all connections to drain
+        # Wait for event loop to finish and all connections to drain.
+        # After loop.stop(), run_until_complete() can fail on asyncio/uvloop;
+        # use the same helper as other shutdown steps so the listener is
+        # actually released before the next test-client request rebinds.
         http_server.close()
-        loop.run_until_complete(http_server.wait_closed())
+        _run_shutdown_coro(loop, http_server.wait_closed)
+        for srv_sock in getattr(http_server, "sockets", None) or ():
+            close_socket(srv_sock)
 
         # Complete all tasks on the loop
         signal.stopped = True
@@ -319,7 +332,7 @@ def _serve_http_1(
         graceful = app.config.GRACEFUL_SHUTDOWN_TIMEOUT
         start_shutdown: float = 0
         while connections and (start_shutdown < graceful):
-            loop.run_until_complete(asyncio.sleep(0.1))
+            _run_shutdown_coro(loop, partial(asyncio.sleep, 0.1))
             start_shutdown = start_shutdown + 0.1
 
         app.shutdown_tasks(graceful - start_shutdown)

--- a/sanic/server/socket.py
+++ b/sanic/server/socket.py
@@ -6,10 +6,16 @@ import stat
 
 from ipaddress import ip_address
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 from sanic.compat import OS_IS_WINDOWS
 from sanic.http.constants import HTTP
+
+
+class _CloseableSocket(Protocol):
+    def shutdown(self, how: int, /) -> None: ...
+
+    def close(self) -> None: ...
 
 
 def _enable_address_reuse(
@@ -33,7 +39,7 @@ def _enable_address_reuse(
             pass
 
 
-def close_socket(sock: socket.socket | None) -> None:
+def close_socket(sock: _CloseableSocket | None) -> None:
     """Shutdown and close a server socket, ignoring already-closed sockets."""
     if sock is None:
         return

--- a/sanic/server/socket.py
+++ b/sanic/server/socket.py
@@ -8,14 +8,53 @@ from ipaddress import ip_address
 from pathlib import Path
 from typing import Any
 
+from sanic.compat import OS_IS_WINDOWS
 from sanic.http.constants import HTTP
 
 
-def bind_socket(host: str, port: int, *, backlog=100) -> socket.socket:
+def _enable_address_reuse(
+    sock: socket.socket, *, reuse_port: bool = False
+) -> None:
+    """Apply address-reuse options before bind/listen.
+
+    SO_REUSEADDR is always enabled so a listening port can be rebound after a
+    previous server socket has closed (including TIME_WAIT).
+
+    SO_REUSEPORT is optional and is intended for Sanic test_mode, where the
+    test client starts and stops a real server on the same host:port for every
+    request. It is not enabled for production binds, and is skipped on Windows
+    where reuse semantics differ.
+    """
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    if reuse_port and not OS_IS_WINDOWS and hasattr(socket, "SO_REUSEPORT"):
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+        except OSError:
+            pass
+
+
+def close_socket(sock: socket.socket | None) -> None:
+    """Shutdown and close a server socket, ignoring already-closed sockets."""
+    if sock is None:
+        return
+    try:
+        sock.shutdown(socket.SHUT_RDWR)
+    except OSError:
+        pass
+    try:
+        sock.close()
+    except OSError:
+        pass
+
+
+def bind_socket(
+    host: str, port: int, *, backlog=100, reuse_port: bool = False
+) -> socket.socket:
     """Create TCP server socket.
     :param host: IPv4, IPv6 or hostname may be specified
     :param port: TCP port number
     :param backlog: Maximum number of connections to queue
+    :param reuse_port: Enable SO_REUSEPORT when available (test_mode)
     :return: socket.socket object
     """
     location = (host, port)
@@ -28,7 +67,7 @@ def bind_socket(host: str, port: int, *, backlog=100) -> socket.socket:
         )
     except ValueError:  # Hostname, may become AF_INET or AF_INET6
         sock = socket.socket()
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    _enable_address_reuse(sock, reuse_port=reuse_port)
     sock.bind(location)
     sock.listen(backlog)
     sock.set_inheritable(True)
@@ -95,6 +134,35 @@ def remove_unix_socket(path: Path | str | None) -> None:
         pass
 
 
+def _reuse_port_from_settings(server_settings: dict[str, Any]) -> bool:
+    app = server_settings.get("app")
+    return bool(getattr(app, "test_mode", False))
+
+
+def _adopt_tcp_socket(
+    sock: socket.socket,
+    *,
+    backlog: int,
+    reuse_port: bool,
+) -> socket.socket:
+    """Ensure a pre-bound TCP socket has reuse options.
+
+    sanic-testing binds an ephemeral socket without SO_REUSEADDR/SO_REUSEPORT
+    and then reuses that port on later requests. Those options must be set
+    before bind(), so a provided socket is rebound when reuse_port is needed.
+    """
+    if not reuse_port:
+        _enable_address_reuse(sock, reuse_port=False)
+        sock.set_inheritable(True)
+        return sock
+
+    host, port, *_ = sock.getsockname()
+    close_socket(sock)
+    adopted = bind_socket(host, port, backlog=backlog, reuse_port=True)
+    adopted.set_inheritable(True)
+    return adopted
+
+
 def configure_socket(
     server_settings: dict[str, Any],
 ) -> socket.SocketType | None:
@@ -104,6 +172,7 @@ def configure_socket(
     sock = server_settings.get("sock")
     unix = server_settings["unix"]
     backlog = server_settings["backlog"]
+    reuse_port = _reuse_port_from_settings(server_settings)
     if unix:
         unix = Path(unix).absolute()
         sock = bind_unix_socket(unix, backlog=backlog)
@@ -113,9 +182,13 @@ def configure_socket(
             server_settings["host"],
             server_settings["port"],
             backlog=backlog,
+            reuse_port=reuse_port,
         )
         sock.set_inheritable(True)
         server_settings["sock"] = sock
         server_settings["host"] = None
         server_settings["port"] = None
+    elif unix is None:
+        sock = _adopt_tcp_socket(sock, backlog=backlog, reuse_port=reuse_port)
+        server_settings["sock"] = sock
     return sock

--- a/tests/test_test_client_port.py
+++ b/tests/test_test_client_port.py
@@ -22,6 +22,28 @@ def test_test_client_port_none(app):
     assert response.status == 405
 
 
+def test_sequential_test_client_get_requests(app):
+    """The WSGI test client starts a server per request on the same port.
+
+    Sequential requests must not fail with EADDRINUSE after the first bind.
+    See: https://github.com/sanic-org/sanic/issues/3128
+    """
+
+    @app.get("/my-endpoint")
+    def handler(request):
+        return text("OK")
+
+    client = SanicTestClient(app, port=None)
+    _, first = client.get("/my-endpoint")
+    assert first.status == 200
+    assert first.text == "OK"
+
+    _, second = client.get("/my-endpoint")
+    assert second.status == 200
+    assert second.text == "OK"
+    assert client.port > 0
+
+
 def test_test_client_port_default(app):
     @app.get("/get")
     def handler(request):

--- a/tests/worker/test_runner.py
+++ b/tests/worker/test_runner.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock, call, patch
 
 import pytest
+
 from sanic.app import Sanic
 from sanic.http.constants import HTTP
 from sanic.server.runners import _run_server_forever, serve
@@ -55,4 +56,31 @@ def test_run_server_forever(remove_unix_socket: Mock, do_cleanup: bool):
         cleanup.assert_not_called()
 
     remove_unix_socket.assert_called_once_with(unix)
+    loop.close.assert_called_once_with()
+
+
+@patch("sanic.server.runners.remove_unix_socket")
+def test_cleanup_error_still_stops(remove_unix_socket: Mock):
+    loop = Mock()
+    loop.run_forever = Mock(side_effect=KeyboardInterrupt())
+    before_stop = Mock()
+    before_stop.return_value = Mock()
+    after_stop = Mock()
+    after_stop.return_value = Mock()
+    cleanup = Mock(side_effect=RuntimeError("loop was stopped"))
+
+    with pytest.raises(KeyboardInterrupt):
+        _run_server_forever(
+            loop,
+            before_stop,
+            after_stop,
+            cleanup,
+            Mock(),
+            12345,
+        )
+
+    cleanup.assert_called_once_with()
+    loop.run_until_complete.assert_has_calls(
+        [call(before_stop.return_value), call(after_stop.return_value)]
+    )
     loop.close.assert_called_once_with()

--- a/tests/worker/test_socket.py
+++ b/tests/worker/test_socket.py
@@ -1,7 +1,15 @@
+import socket
+
 from pathlib import Path
 
+import pytest
+
+from sanic import Sanic
+from sanic.compat import OS_IS_WINDOWS
 from sanic.server.socket import (
+    bind_socket,
     bind_unix_socket,
+    close_socket,
     configure_socket,
     remove_unix_socket,
 )
@@ -25,3 +33,72 @@ def test_configure_socket():
     assert path.exists()
     remove_unix_socket(socket_address)
     assert not path.exists()
+
+
+def test_bind_socket_rebinds_same_port_after_close():
+    first = bind_socket("127.0.0.1", 0)
+    host, port = first.getsockname()[:2]
+    close_socket(first)
+    second = bind_socket(host, port)
+    assert second.getsockname()[:2] == (host, port)
+    close_socket(second)
+
+
+def test_bind_socket_does_not_share_port_by_default():
+    first = bind_socket("127.0.0.1", 0)
+    host, port = first.getsockname()[:2]
+    try:
+        with pytest.raises(OSError):
+            bind_socket(host, port)
+    finally:
+        close_socket(first)
+
+
+@pytest.mark.skipif(
+    OS_IS_WINDOWS or not hasattr(socket, "SO_REUSEPORT"),
+    reason="SO_REUSEPORT is not available",
+)
+def test_bind_socket_can_share_port_when_reuse_port_enabled():
+    first = bind_socket("127.0.0.1", 0, reuse_port=True)
+    host, port = first.getsockname()[:2]
+    try:
+        second = bind_socket(host, port, reuse_port=True)
+        assert second.getsockname()[:2] == (host, port)
+        close_socket(second)
+    finally:
+        close_socket(first)
+
+
+@pytest.mark.skipif(
+    OS_IS_WINDOWS or not hasattr(socket, "SO_REUSEPORT"),
+    reason="SO_REUSEPORT is not available",
+)
+def test_configure_socket_adopts_test_client_socket(app):
+    """sanic-testing binds without reuse options, then reuses the same port.
+
+    See: https://github.com/sanic-org/sanic/issues/3128
+    """
+    previous = Sanic.test_mode
+    Sanic.test_mode = True
+    adopted = None
+    try:
+        raw = socket.socket()
+        raw.bind(("127.0.0.1", 0))
+        host, port = raw.getsockname()
+
+        adopted = configure_socket(
+            {
+                "sock": raw,
+                "unix": None,
+                "backlog": 100,
+                "app": app,
+            }
+        )
+        assert adopted is not None
+        assert adopted.getsockname()[:2] == (host, port)
+        other = bind_socket(host, port, reuse_port=True)
+        assert other.getsockname()[:2] == (host, port)
+        close_socket(other)
+    finally:
+        close_socket(adopted)
+        Sanic.test_mode = previous


### PR DESCRIPTION
## Summary

- Adopt sockets created by sanic-testing so test-mode binds set SO_REUSEADDR and, on POSIX, SO_REUSEPORT before bind(). The first request binds an ephemeral socket without those options and later requests reuse that port.
- Close listening sockets after loop.stop() using the existing uvloop-safe shutdown helper, and shut down sockets in serve_single the same way as multi-worker serve. A leftover listener is what actually produces OSError: [Errno 98] Address already in use.
- Production binds still do not enable SO_REUSEPORT, so two listeners cannot share a port outside Sanic.test_mode.

fixes #3128

## Validation

- python -m pytest tests/worker/test_socket.py tests/test_test_client_port.py tests/worker/test_runner.py -q — 14 passed
- python -m ruff check on the touched files — passed