### PR TITLE
docs: use condition= rather than conditions= in the signals guide

### DIFF
--- a/guide/content/en/guide/advanced/signals.md
+++ b/guide/content/en/guide/advanced/signals.md
@@ -58,10 +58,10 @@ async def handle_registration(request):
     app.add_signal(
         my_signal_handler,
         "something.happened.ohmy1",
-        conditions={"some_condition": "value"}
+        condition={"some_condition": "value"}
     )
 
-    @app.signal("something.happened.ohmy2", conditions={"some_condition": "value"})
+    @app.signal("something.happened.ohmy2", condition={"some_condition": "value"})
     async def my_signal_handler2():
         print("something happened")
     ```


### PR DESCRIPTION
Both snippets in the signals guide pass `conditions=`, but neither API accepts that name:

- `add_signal()` (`sanic/mixins/signals.py:71`) declares `condition`
- `signal()` (`sanic/mixins/signals.py:21`) declares `condition`

and `Route.matches()` / `Signal.dispatch()` use `condition` throughout, so both examples raise `TypeError` exactly as written.

Two lines changed, nothing else touched.

Fixes #3176.

---

@nightcityblade said in #3176 (2026-07-25) that they wanted to pick this up. It has been quiet for six weeks with no PR, so I went ahead — happy to close this straight away if you are already working on it.