### PR TITLE
fix: annotate BasePage.HEADING so type-checking passes on main

### DIFF
--- a/sanic/pages/base.py
+++ b/sanic/pages/base.py
@@ -11,7 +11,7 @@ class BasePage(ABC, metaclass=CSS):  # no cov
     """Base page for Sanic pages."""
 
     TITLE = "Sanic"
-    HEADING = None
+    HEADING: Builder | None = None
     CSS: str
     doc: Builder
 


### PR DESCRIPTION
## What this fixes

`mypy` rejects one assignment in `sanic/pages/error.py`, and that single error currently turns the `type-checking` job red for **every** PR based on `main`:

```text
sanic/pages/error.py:43: error: Incompatible types in assignment (expression has type "Builder", variable has type "None")  [assignment]
Found 1 error in 1 file (checked 132 source files)
```

`BasePage.HEADING = None` has no annotation, so its inferred type is `None`. `ErrorPage.__init__` assigns `E("Application ").strong(name)(...)`, which is an `html5tagger.Builder`.

Because the `Tests` matrix is fail-fast, that one job cancels the remaining jobs, and `Coverage check` then fails as a knock-on effect (`No files were found with the provided path: ./coverage.xml`). The result is that PRs such as #3178, #3185 and #3189 show red CI that has nothing to do with their own changes.

## The change

One line, in `sanic/pages/base.py`:

```diff
-    HEADING = None
+    HEADING: Builder | None = None
```

`Builder | None` is what the code actually assigns - `HEADING` is only ever `None` (the base class default) or a `Builder` (from `error.py`). It is never a `str`. `Builder` is already imported at the top of `base.py`, and `python_requires` is `>=3.10`, so the PEP 604 syntax needs no `from __future__ import annotations`.

## Verification

With `mypy==2.3.1` and `html5tagger==2.0.0` (the versions the type-checking env resolves to):

```text
reveal_type(BasePage.HEADING)
# before: Revealed type is "None"
# after:  Revealed type is "html5tagger.builder.Builder | None"
```

A full local `mypy sanic` run is dominated by unrelated errors from optional dependencies my environment lacks, so I verified the inferred type directly rather than by total error count.

The stronger evidence is CI's own history: #3188 carried this annotation and its `type-checking` jobs were green from 09-01 with identical toolchain versions, while #3189 - based on the same, unmodified `main` - fails on this one error. #3188 has since been closed unmerged, which is why this is being opened separately.

## Scope

Deliberately limited to the annotation. There is no runtime behaviour change: it is a type-annotation-only change to a class attribute that is still assigned `None`.

I left the equivalent line out of my own PRs (#3185, #3189) on purpose so as not to duplicate #3188. With #3188 closed, this is no longer competing with anyone's work.
