### PR TITLE
test: pin uvicorn<0.50 so the test extras resolve a working websockets pair

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -143,7 +143,7 @@ tests_require = [
     "mypy",
     "docutils",
     "pygments",
-    "uvicorn",
+    "uvicorn<0.50",
     "slotscheck>=0.8.0,<1",
     types_ujson,
 ]


### PR DESCRIPTION
## What this fixes

`Coverage check` has been red on every PR since 2026-07-12, and `Tests / py311-no-ext` fails for the same reason. Neither is caused by the PRs' own changes - it is a dependency-resolution conflict in the test extras.

## Evidence

`Coverage check` last passed on 2026-07-03 ([run 28673787787](https://github.com/sanic-org/sanic/actions/runs/28673787787)) and first failed on 2026-07-12 ([run 29183931475](https://github.com/sanic-org/sanic/actions/runs/29183931475)). `websockets` did not move between those runs - it is `10.4` in both. What moved is `uvicorn`: `0.49.0` -> `0.51.0`.

The failure is:

```text
ImportError: cannot import name 'ServerProtocol' from 'websockets.server'
```

raised from `uvicorn/protocols/websockets/websockets_sansio_impl.py`, and it hits `tests/test_asgi.py::test_listeners_triggered` and `::test_listeners_triggered_async`.

Two facts pin it down:

1. **uvicorn 0.50.0 switched the implementation it uses when `websockets` is importable.** In `uvicorn/protocols/websockets/auto.py` that branch changed from

   ```python
   from uvicorn.protocols.websockets.websockets_impl import WebSocketProtocol
   ```

   to

   ```python
   from uvicorn.protocols.websockets.websockets_sansio_impl import WebSocketsSansIOProtocol
   ```

   `websockets_sansio_impl` imports `ServerProtocol` from `websockets.server`, which only exists in `websockets>=13`.

2. **The test extras cap `websockets` below 11**, so pip can never satisfy that. It is `pytest-sanic 1.9.1`, which declares `websockets>=9.1,<11.0`. Left alone the resolver picks `websockets==10.4` - that is stable across every run I looked at, including the ones that were green.

So `uvicorn>=0.50` and `pytest-sanic` are mutually unsatisfiable: the first needs `websockets>=13`, the second forbids it. `uvicorn` only declares `websockets>=13.0` under its `standard` extra, so pip sees no conflict at install time and the pair blows up at import time instead.

## The change

One line, in `setup.py`'s `tests_require`:

```diff
-    "uvicorn",
+    "uvicorn<0.50",
```

`tests_require` only feeds the `test` and `dev` extras, so a plain `pip install sanic` is unaffected.

Verified with the resolver against this branch (`pip install --dry-run --report -e ".[test,http3]"`):

| | uvicorn | websockets | pytest-sanic |
| --- | --- | --- | --- |
| before | 0.52.4 | 10.4 | 1.9.1 |
| after | 0.49.0 | 10.4 | 1.9.1 |

which is the exact combination that produced the green `Coverage check` on 07-03.

## Why a cap rather than an upgrade

Raising `websockets` to `>=13` is not currently installable: `pytest-sanic 1.9.1` (the current release) hard-caps it at `<11.0`, and pip reports `ResolutionImpossible` rather than picking something. The cleaner long-term fix is to loosen that cap in `sanic-org/pytest-sanic` and then raise the floor here, but that needs a release from the other project first - and every PR in this repo is red until then. This cap restores the last known-good state and touches no runtime dependency.

For context, this is the third round of the same conflict: #1629, #2734, #3030.

## Note on `Coverage check`

That job fails at `actions/upload-artifact@v4` with `No files were found with the provided path: ./coverage.xml`, which is a knock-on effect rather than a second fault: `tox -e coverage` runs `coverage run --source ./sanic -m pytest tests`, that command exits 1 on the ImportError above, so the `coverage xml -i` step in the same env never runs and no report is produced.

*(Correction to something I said elsewhere: on 09-05 I claimed this job fails with `failed to determine base repo: failed to run git: ...` and called it a fault in the workflow itself. That was wrong - I have checked nine runs from 08-11 to 09-05 and none contains that text; they all fail on the missing `coverage.xml`.)*

## Scope

Test-infrastructure only. No change to `sanic/` itself, and no change to what end users install.
